### PR TITLE
build: link pthread, thus fixing build issue on Fedora

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ ${BUILDDIR}/%.o: src/%.c src/%.h deps
 	$(CC) -Wall -Werror -c $< -o $@ -I${HTTPDIR} -I${UVDIR}/include -I${LUADIR}/src -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
 
 ${BUILDDIR}/luvit: ${GENDIR} ${ALLLIBS}
-	$(CC) -o ${BUILDDIR}/luvit ${ALLLIBS} -Wall -lm -ldl -lrt -Wl,-E
+	$(CC) -o ${BUILDDIR}/luvit ${ALLLIBS} -Wall -lm -ldl -lrt -lpthread -Wl,-E
 
 clean:
 	make -C ${LUADIR} clean


### PR DESCRIPTION
This is the fix for this issue we've talked about on IRC. 

Please, make sure that it works on your OS.

For posterity's sake, part of failed compilation log:

```
cc -o build/luvit build/luvit.o build/utils.o build/luv_fs.o build/luv_handle.o build/luv_udp.o build/luv_fs_watcher.o build/luv_timer.o build/luv_process.o build/luv_stream.o build/luv_tcp.o build/luv_pipe.o build/luv_tty.o build/luv_misc.o build/lenv.o build/lhttp_parser.o build/luv.o deps/luajit/src/libluajit.a deps/uv/uv.a deps/http-parser/http_parser.o build/generated/luvit.o build/generated/http.o build/generated/url.o build/generated/request.o build/generated/response.o build/generated/fs.o build/generated/process.o build/generated/emitter.o build/generated/udp.o build/generated/stream.o build/generated/tcp.o build/generated/pipe.o build/generated/tty.o build/generated/timer.o build/generated/repl.o build/generated/fiber.o build/generated/mime.o build/generated/utils.o -Wall -lm -ldl -lrt -Wl,-E
/usr/bin/ld: deps/uv/uv.a(eio.o): undefined reference to symbol 'pthread_sigmask@@GLIBC_2.2.5'
/usr/bin/ld: note: 'pthread_sigmask@@GLIBC_2.2.5' is defined in DSO /lib64/libpthread.so.0 so try adding it to the linker command line
/lib64/libpthread.so.0: could not read symbols: Invalid operation
collect2: ld returned 1 exit status
make: *** [build/luvit] Błąd 1
```
