### PR TITLE
fix runtime on osx

### DIFF
--- a/deps/Makefile.yajl
+++ b/deps/Makefile.yajl
@@ -36,5 +36,5 @@ src/api/yajl:
 	ln -s . src/api/yajl 
 
 build/%.o: src/%.c build src/api/yajl src/api/yajl_version.h
-	$(CC) -g -Wall -c $< -o $@ -I src/api
+	$(CC) ${CFLAGS} -g -Wall -c $< -o $@ -I src/api
 


### PR DESCRIPTION
this patch forces to build for x86_32 on OSX. looks like 64bit version is problematic, building it for 32 bits works
