### PR TITLE
allow lua-config.lua work with symlinked luvit binary

### DIFF
--- a/bin/luvit-config.lua
+++ b/bin/luvit-config.lua
@@ -29,7 +29,14 @@ if command == "--libs" then
 elseif command == "--cflags" then
   local Path = require('path')
   local UV = require('uv')
+  local Fs = require('fs')
+  -- calculate includes relative to the binary
   local include_dir = Path.resolve(Path.dirname(UV.execpath()), "../include/luvit")
+  -- if not found...
+  if not Fs.exists_sync(include_dir) then
+    -- calculate includes relative to the symlink to the binary
+    include_dir = Path.resolve(__dirname, "../include/luvit")
+  end
   local flags = {
     "-I" .. include_dir,
     "-I" .. include_dir .. "/http_parser",


### PR DESCRIPTION
E.g. in case you did `sudo ln -s /path/to/luvit /usr/local/bin`, to ease development
Please, consider applying
