### PR TITLE
accomodate for the latest http_parser -- excess parser:finish() removed

### DIFF
--- a/lib/http.lua
+++ b/lib/http.lua
@@ -153,11 +153,6 @@ function HTTP.create_server(host, port, on_connection)
           on_connection(request, response)
         end
 
-        -- We're done with the parser once we hit an upgrade
-        if request.upgrade then
-          parser:finish()
-        end
-
       end,
       on_body = function (chunk)
         request:emit('data', chunk, #chunk)


### PR DESCRIPTION
the change is empiric -- w/o it all connections with Upgrade: header are dropped
