### PR TITLE
delegate error events from http parser to higher levels

### DIFF
--- a/lib/http.lua
+++ b/lib/http.lua
@@ -477,6 +477,14 @@ function http.createServer(host, port, onConnection)
       parser:finish()
     end)
 
+    client:on("error", function (err)
+      request:emit("error", err)
+      -- N.B. must close(), or https://github.com/joyent/libuv/blob/master/src/unix/stream.c#L586
+      -- kills the appication
+      client:close()
+      parser:finish()
+    end)
+
   end)
 
   server:listen(port, host)


### PR DESCRIPTION
i believe the same should be applied to http.request
