### PR TITLE
luvit.lua: don't use tty on windows

### DIFF
--- a/lib/luvit/fs.lua
+++ b/lib/luvit/fs.lua
@@ -245,5 +245,30 @@ function Watcher:initialize(path)
   self.userdata = uv.newFsWatcher(path)
 end
 
+local SyncWriteStream = iStream:extend()
+
+-- Copy hack from nodejs to stdout and stderr to piped file
+function SyncWriteStream:initialize(fd)
+  self.fd = fd
+end
+
+function SyncWriteStream:write(chunk, callback)
+  return fs.writeSync(self.fd, 0, chunk)
+end
+
+function SyncWriteStream:finish(chunk, callback)
+  if (chunk ~= nil) then
+    self:write(chunk)
+  end
+  self:emit("end")
+  self:close()
+end
+
+function SyncWriteStream:close(chunk, callback)
+  fs.closeSync(self.fd)
+end
+
+fs.SyncWriteStream = SyncWriteStream
+
 return fs
 

--- a/lib/luvit/luvit.lua
+++ b/lib/luvit/luvit.lua
@@ -40,6 +40,7 @@ local table = require('table')
 local utils = require('utils')
 local fs = require('fs')
 local Tty = require('tty').Tty
+local Pipe = require('pipe').Pipe
 local Emitter = require('core').Emitter
 local constants = require('constants')
 local path = require('path')
@@ -118,10 +119,23 @@ if luvit_os ~= "win" then
   uv.unref()
 end
 
+local createWriteableStdioStream = function(fd)
+  local fd_type uv.handleType(fd);
+  if (fd_type == "TTY") then
+    return Tty:new(fd)
+  else if (fd_type == "FILE") then
+    return fs.SyncWriteStream(fd)
+  else
+    local pipe = Pipe:new(0)
+    pipe:open(fd)
+    return pipe
+  end
+end
+
 -- Load the tty as a pair of pipes
 -- But don't hold the event loop open for them
-process.stdin = Tty:new(0)
-process.stdout = Tty:new(1)
+process.stdin = createWriteableStdioStream(0)
+process.stdout = createWriteableStdioStream(1)
 local stdout = process.stdout
 uv.unref()
 uv.unref()


### PR DESCRIPTION
Windows's TTYs aren't pipes. Copy the logic from nodejs
https://github.com/joyent/node/blob/master/src/node.js#L221-274
