### PR TITLE
modules.require: make relative paths for require the same no matter the ...

### DIFF
--- a/lib/luvit/module.lua
+++ b/lib/luvit/module.lua
@@ -130,6 +130,9 @@ local libpath = process.execPath:match('^(.*)' .. path.sep .. '[^' ..path.sep.. 
 function module.require(filepath, dirname)
   if not dirname then dirname = base_path end
 
+  -- Let module paths always use / even on windows
+  filepath = filepath:gsub("/", path.sep)
+
   -- Absolute and relative required modules
   local absolute_path
   if filepath:sub(1, path.root:len()) == path.root then

--- a/tests/test-require.lua
+++ b/tests/test-require.lua
@@ -21,13 +21,13 @@ local path = require("path")
 
 _G.num_loaded = 0
 local m1 = require("module1")
-local m1_m2 = require(path.join("module1", "module2"))
-local m1_m2 = require(path.join("module1", "module2"))
-local m1_m2 = require(path.join("module1", "module2"))
-local m2_m2 = require(path.join("module2", "module2"))
-local rm1 = require(path.join(".", "modules", "module1"))
-local rm1_m2 = require(path.join(".", "modules", "module1", "module2"))
-local rm2_m2 = require(path.join(".", "modules", "module2", "module2"))
+local m1_m2 = require("module1/module2")
+local m1_m2 = require("module1/module2")
+local m1_m2 = require("module1/module2")
+local m2_m2 = require("module2/module2")
+local rm1 = require("./modules/module1")
+local rm1_m2 = require("./modules/module1/module2")
+local rm2_m2 = require("./modules/module2/module2")
 
 printStderr("require: " .. tostring(require))
 
@@ -49,7 +49,7 @@ assert(vectors[1] == vectors[2], "Symlinks should realpath and load real module 
 -- Test to make sure dashes are allowed and the same file is cached no matter how it's found
 local libluvits = {
   require('lib-luvit'),
-  require(path.join('.', 'modules', 'lib-luvit')),
+  require('./modules/lib-luvit'),
 }
 assert(libluvits[1] == libluvits[2], "Module search and relative should share same cache")
 


### PR DESCRIPTION
...platform

follow in the footsteps of nodejs and make relative paths for require
work the same no matter the hosting OS.

require('../../mymodule')
require('./mymodule')
require('mymodule')

Should all work no matter the OS.

Tested on OSX and Windows OK
