### PR TITLE
luvit: path: add os path modules

### DIFF
--- a/tests/test-path.lua
+++ b/tests/test-path.lua
@@ -31,3 +31,11 @@ else
   assert(path.dirname('C:\\Users\\philips\\') == 'C:\\Users')
   assert(path.dirname('C:\\Users\\philips\\') == 'C:\\Users')
 end
+
+-- Test out the OS path objects
+assert(path.posix:dirname('/usr/bin/vim') == '/usr/bin')
+assert(path.posix:dirname('/usr/bin/') == '/usr')
+assert(path.posix:dirname('/usr/bin') == '/usr')
+assert(path.nt:dirname('C:\\Users\\philips\\vim.exe') == 'C:\\Users\\philips')
+assert(path.nt:dirname('C:\\Users\\philips\\') == 'C:\\Users')
+assert(path.nt:dirname('C:\\Users\\philips\\') == 'C:\\Users')


### PR DESCRIPTION
On Windows you may want to join Unix paths and vice versa.

Follow in the footsteps of Python and provide a global path object that
does the right thing by default on the current platform but then also
provide a path.nt and path.posix object for Windows and posix

This does not change the path API

Example usage:

```
path.posix:dirname('/usr/bin/vim') == '/usr/bin')
path.nt:dirname('C:\\Users\\philips\\vim.exe') == 'C:\\Users\\philips')
```
