### PR TITLE
chunked encoding for http.request

### DIFF
--- a/examples/test-http-ugly.lua
+++ b/examples/test-http-ugly.lua
@@ -75,7 +75,7 @@ request = http.request(
     method = 'POST',
     headers = {
       bar = "cats",
-      --['Content-Length'] = #payload,
+      --['Content-Length'] = #payload * 2 + 4,
     }
   },
   function (conn)


### PR DESCRIPTION
Please, consider applying. It surely needs further luv, as http.request writable channel could reuse http.Response methods. ugly-http example is passing now. TIA
