### PR TITLE
fix error when managing repl errors

### DIFF
--- a/lib/luvit/repl.lua
+++ b/lib/luvit/repl.lua
@@ -77,6 +77,7 @@ function repl.evaluateLine(line)
       return '>>'
     else
       print(err)
+      buffer = ''
     end
   end
 


### PR DESCRIPTION
$ luvit

> a=new b
> 
> > ()
> > [string "REPL"] ... error
> > a = 3
> > [string "REPL"] ... error

... after the multiline parse error the repl is doomed and will not work anymore. this patch fixes this issue
