### PR TITLE
Implemented dynamic openssl build

### DIFF
--- a/src/luv_tls.c
+++ b/src/luv_tls.c
@@ -14,6 +14,7 @@
  *  limitations under the License.
  *
  */
+#include <openssl/ssl.h>
 
 
 #include "luv.h"
@@ -31,8 +32,10 @@
  * too easily to accidently pull in an older version of OpenSSL on random platforms with
  * weird include paths.
  */
+#if !USE_SYSTEM_SSL
 #if OPENSSL_VERSION_NUMBER != LUVIT_OPENSSL_VERSION_NUMBER
 #error Invalid OpenSSL version number. Busted Include Paths?
+#endif
 #endif
 
 #define TLS_SECURE_CONTEXT_HANDLE "ltls_secure_context"

--- a/src/luv_tls_conn.c
+++ b/src/luv_tls_conn.c
@@ -38,8 +38,10 @@
  * too easily to accidently pull in an older version of OpenSSL on random platforms with
  * weird include paths.
  */
+#if !USE_SYSTEM_SSL
 #if OPENSSL_VERSION_NUMBER != LUVIT_OPENSSL_VERSION_NUMBER
 #error Invalid OpenSSL version number. Busted Include Paths?
+#endif
 #endif
 
 /* TLS object that maps to an individual connection */


### PR DESCRIPTION
This patch checks for system openssl with pkg-config.

This determines the value of USE_SYSTEM_SSL variable in Makefile from 0 to 1.

Build with SSL = 2.5MB, without = 800K
