### PR TITLE
lib: utils: stop using Bwhite and add B color

### DIFF
--- a/lib/luvit/repl.lua
+++ b/lib/luvit/repl.lua
@@ -95,7 +95,7 @@ function repl.start()
     process.stdout:write(prompt .. ' ', noop)
   end
 
-  print(c("Bwhite") .. "Welcome to the " .. repl.colored_name() .. c("Bwhite") .. " repl" .. c())
+  print(c("B") .. "Welcome to the " .. repl.colored_name() .. c("B") .. " repl" .. c())
 
   displayPrompt '>'
 

--- a/lib/luvit/utils.lua
+++ b/lib/luvit/utils.lua
@@ -29,6 +29,7 @@ local colors = {
   magenta = "0;35",
   cyan    = "0;36",
   white   = "0;37",
+  B        = "1;",
   Bblack   = "1;30",
   Bred     = "1;31",
   Bgreen   = "1;32",
@@ -66,8 +67,8 @@ function utils.loadColors (n)
   tab       = utils.colorize("Bgreen", "\\t", "green")
   quote     = utils.colorize("Bgreen", '"', "green")
   quote2    = utils.colorize("Bgreen", '"')
-  obracket  = utils.colorize("white", '[')
-  cbracket  = utils.colorize("white", ']')
+  obracket  = utils.colorize("B", '[')
+  cbracket  = utils.colorize("B", ']')
 end
 
 utils.loadColors ()

--- a/tests/runner.lua
+++ b/tests/runner.lua
@@ -39,7 +39,7 @@ local function runTest(filename, callback)
   results[filename].stderr_data = ''
   results[filename].filename = filename
 
-  process.stdout:write(utils.color("Bwhite") .. filename .. utils.color())
+  process.stdout:write(utils.color("B") .. filename .. utils.color())
 
   ports = ports + 100
 


### PR DESCRIPTION
Bwhite makes test and the repl output impossible to read on light background
terminals (the default for a lot of OSes)

Bold the default foreground color instead of using Bwhite
