### PR TITLE
deps/luacrypto: use the luvit/luacrypto repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,4 +18,4 @@
 	url = https://github.com/luvit/openssl.git
 [submodule "deps/luacrypto"]
 	path = deps/luacrypto
-	url = http://github.com/racker/luacrypto
+	url = http://github.com/luvit/luacrypto


### PR DESCRIPTION
use the luacrypto repo tied to the luvit account instead of racker this
will require people to rm -R deps/luacrypto if they have the old repo.
