### PR TITLE
api.markdown: remove instance of :end()

### DIFF
--- a/api.markdown
+++ b/api.markdown
@@ -158,7 +158,7 @@ Half-closes the socket. i.e., it sends a FIN packet. It is possible the
 server will still send some data.
 
 If `data` is specified, it is equivalent to calling
-`socket:write(data)` followed by `socket.end()`.
+`socket:write(data)` followed by `socket:finish()`.
 
 #### Socket:initialize(options)
 


### PR DESCRIPTION
the document incorrectly mentions :end(). We can't use end() because it
is reserved in lua.
