### PR TITLE
luvit.gyp: add -g flag to luajit

### DIFF
--- a/luvit.gyp
+++ b/luvit.gyp
@@ -114,7 +114,7 @@
          ],
          'action': [
            '<(PRODUCT_DIR)/luajit',
-           '-b', '<(RULE_INPUT_PATH)',
+           '-b', '-g', '<(RULE_INPUT_PATH)',
            '<(SHARED_INTERMEDIATE_DIR)/generated/<(RULE_INPUT_ROOT)_jit.c',
          ],
          'process_outputs_as_sources': 1,


### PR DESCRIPTION
with -g we get line numbers in tracebacks. This is very useful and
should be on by default.
