### PR TITLE
tls: hookup passing back the error string to lua

### DIFF
--- a/tests/test-tls-connect-simple-twice.lua
+++ b/tests/test-tls-connect-simple-twice.lua
@@ -1,0 +1,43 @@
+require('helper')
+local fixture = require('./fixture-tls')
+local tls = require('tls')
+
+local options = {
+  cert = fixture.certPem,
+  key = fixture.keyPem
+}
+
+local serverConnected = 0
+local clientConnected = 0
+
+local server
+server = tls.createServer(options, function(conn)
+  serverConnected = serverConnected + 1
+  if (serverConnected == 2) then
+    server:close()
+  end
+end)
+
+server:listen(fixture.commonPort, function()
+  local client1, client2
+  client1 = tls.connect({port = fixture.commonPort, host = '127.0.0.1'}, {}, function()
+    clientConnected = clientConnected + 1
+    client1:destroy()
+
+    client2 = tls.connect({port = fixture.commonPort, host = '127.0.0.1'}, {}, function()
+      clientConnected = clientConnected + 1
+      client2:destroy()
+    end)
+  end)
+end)
+
+process:on('error', function(err)
+  print('unhandled error!')
+  p(err)
+  assert(false)
+end)
+
+process:on('exit', function()
+  assert(serverConnected == 2)
+  assert(clientConnected == 2)
+end)


### PR DESCRIPTION
Before Ryan's cert fix I was debugging what was happening. In the
process I hooked up getting the error string back out to lua and
emitting an error event.

e.g. test-tls-connect-simple-twice returned:

```
unhandled error!
"140646688597824:error:0D07209B:asn1 encoding routines:ASN1_get_object:too long:../deps/openssl/openssl/crypto/asn1/asn1_lib.c:142:\n140646688597824:error:0D068066:asn1 encoding routines:ASN1_CHECK_TLEN:bad object header:../deps/openssl/openssl/crypto/asn1/tasn_dec.c:1306:\n140646688597824:error:0D07803A:asn1 encoding routines:ASN1_ITEM_EX_D2I:nested asn1 error:../deps/openssl/openssl/crypto/asn1/tasn_dec.c:381:Type=X509\n140646688597824:error:0906700D:PEM routines:PEM_ASN1_read_bio:ASN1 lib:../deps/openssl/openssl/crypto/pem/pem_oth.c:83:\n"
  FAIL assert - assertion failed - Line: 37
```
