### PR TITLE
luvit: add process.exitCode

### DIFF
--- a/examples/exit-code.lua
+++ b/examples/exit-code.lua
@@ -1,0 +1,3 @@
+-- exit luvit with exit code 3 in the event of a pre-mature
+-- event loop exit
+process.exitCode = 3

--- a/lib/luvit/luvit.lua
+++ b/lib/luvit/luvit.lua
@@ -313,4 +313,4 @@ end, traceback))
 -- Start the event loop
 native.run()
 -- trigger exit handlers and exit cleanly
-process.exit(0)
+process.exit(process.exitCode or 0)


### PR DESCRIPTION
It has happened a few times that the luvit event loop has exited before
we expected in our application due to bugs in luvit. It would be great
to be able to set the exitCode so that if we exit the loop before our
application expects it we can have a failing exit code.

Example usage:

```
-- exit luvit with exit code 3 in the event of a pre-mature
-- event loop exit
process.exitCode = 3
```
