### PR TITLE
luvit_init: remove function call from assert()

### DIFF
--- a/src/luvit_init.c
+++ b/src/luvit_init.c
@@ -245,7 +245,8 @@ int luvit_init(lua_State *L, uv_loop_t* loop, int argc, char *argv[])
 #endif
 
   /* Hold a reference to the main thread in the registry */
-  assert(lua_pushthread(L) == 1);
+  rc = lua_pushthread(L);
+  assert(rc == 1);
   lua_setfield(L, LUA_REGISTRYINDEX, "main_thread");
 
   /* Store the loop within the registry */


### PR DESCRIPTION
Fix #156.

assert() statements can be compiled out, don't do functional things in
them.

Note from Brandon: I searched the rest of the tree for assert() with
side effects and didn't see anything else.
