### PR TITLE
File writetype

### DIFF
--- a/lib/luvit/fs.lua
+++ b/lib/luvit/fs.lua
@@ -231,6 +231,9 @@ function fs.writeFileSync(path, data)
 end
 
 function fs.writeFile(path, data, callback)
+  if not type(data) == 'string' then
+    error('data parameter must be a string')
+  end
   fs.open(path, "w", "0666", function (err, fd)
     if err then return callback(err) end
     local offset = 0


### PR DESCRIPTION
One-line assert to fix issue 231 I posed recently. Allows for break in fs.fileWrite before length is computed, making the reason for breaking a little more clear to the developer. 
