### PR TITLE
Added uninstall to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,9 +227,9 @@ install: all
 	cp src/*.h ${INCDIR}/
 
 uninstall:
-	rm -f ${BINDIR}/luvit
-	rm -rf ${LIBDIR}
-	rm -rf ${INCDIR}
+	test -f ${BINDIR}/luvit && rm -f ${BINDIR}/luvit
+	test -d ${LIBDIR} && rm -rf ${LIBDIR}
+	test -d ${INCDIR} && rm -rf ${INCDIR}
 
 bundle: bundle/luvit
 


### PR DESCRIPTION
Added a simple 4 line uninstall into the Makefile to make it simple to remove luvit.

I did this as I wanted to create a homebrew formula (http://mxcl.github.com/homebrew/) for luvit and needed to get uninstalling working.

Tested on MacOSX 10.7
