### PR TITLE
Make sure chunk is a string.

### DIFF
--- a/lib/luvit/http.lua
+++ b/lib/luvit/http.lua
@@ -465,7 +465,6 @@ function http.request(options, callback)
   -- while connecting, we want to buffer writes and closes
   client.write = function (self, chunk, callback)
     chunk = chunk and chunk or ''
-
     if #chunk > 0 then
       if headers["Transfer-Encoding"] == "chunked" then
         content[#content + 1] = stringFormat("%x\r\n%s\r\n", #chunk, chunk)


### PR DESCRIPTION
if you don't send any data with the request it till throw an error because internally `write` gets called without a chunk argument.

```
(-2) Runtime error: /modules/http.lua:466: attempt to get length of local 'chunk' (a nil value)
```
