### PR TITLE
Make fiber sugar more useful.

### DIFF
--- a/examples/fs-coroutines.lua
+++ b/examples/fs-coroutines.lua
@@ -1,47 +1,58 @@
-local fs = require('fs')
-local timer = require('timer')
-local fiber = require('fiber')
+local fiber = require 'fiber'
 
-fiber.new(function (resume, wait)
+local function logic(wrap)
+  -- Wrap some functions for sync-style calling
+  local sleep = wrap(require('timer').setTimeout)
+  -- Can wrap modules too
+  local fs = wrap(require('fs'), true) -- true means to auto-handle errors
 
   print("opening...")
-  fs.open(__dirname .. "/../LICENSE.txt", "r", "0644", resume)
-  local err, fd = wait()
-
-  p("on_open", {err=err,fd=fd})
+  local fd = fs.open(__filename, "r", "0644")
+  p("on_open", {fd=fd})
 
   print("fstatting...")
-  fs.fstat(fd, resume)
-  local err, stat = wait()
-  p("stat", {err=err,stat=stat})
+  local stat = fs.fstat(fd)
+  p("stat", {stat=stat})
 
   print("reading...")
   local offset = 0
   repeat
-    fs.read(fd, offset, 72, resume)
-    local err, chunk, length = wait()
-    p("on_read", {err=err,chunk=chunk, offset=offset, length=length})
+    local chunk, length = fs.read(fd, offset, 40)
+    p("on_read", {chunk=chunk, offset=offset, length=length})
     offset = offset + length
   until length == 0
 
   print("pausing...")
-  timer.setTimeout(400, resume)
-  wait()
+  sleep(1000)
 
   print("closing...")
-  fs.close(fd, resume)
-  local err = wait()
-  p("on_close", {err=err})
+  fs.close(fd)
+  p("on_close", {})
 
+  return fd, stat, offset
+
+end
+
+print "Starting fiber."
+fiber.new(logic, function (err, fd, stat, offset)
+  if err then
+    p("ERROR", err)
+    error(err)
+  else
+    p("SUCCESS", { fd = fd, stat = stat, offset = offset })
+  end
 end)
+print "started."
 
-fiber.new(function (resume, wait)
+print "Starting another fiber."
+fiber.new(function (wrap)
 
+  local readdir = wrap(require('fs').readdir)
   print("scanning directory...")
-  fs.readdir(".", resume)
-  local err, files = wait()
+  local err, files = readdir(".")
   p("on_open", {err=err,files=files})
 
 end)
+print "started second."
 
 


### PR DESCRIPTION
Changed syntax of fiber.new to pass a wrap function to the block.  Also
accepts a callback to be notified when the block finishes or errors out.
