### PR TITLE
Rough draft of how the docs may look.

### DIFF
--- a/docs/querystring.md
+++ b/docs/querystring.md
@@ -1,0 +1,77 @@
+# Query String
+
+Helper for parsing, encoding and decoding query strings
+
+## querystring.parse(str, [sep], [eq])
+
+Parses a querystring, returning table of url decoded tokens.
+
+Optionally override the default separator ('&') and assignment ('=') characters.
+
+### Examples
+
+```lua
+local qs = require("querystring")
+
+local to_parse = "name=luvit&version=0.4.0"
+local parsed = qs.parse(to_parse)
+for i,v in pairs(parsed) do print(i,v) end
+
+--[[
+Output
+    name	luvit
+    version	0.4.0
+]]--
+```
+
+```lua
+local qs = require("querystring")
+
+local to_parse = "name==luvit||version==0.4.0"
+local parsed = qs.parse(to_parse, "||", "==")
+for i,v in pairs(parsed) do print(i,v) end
+
+--[[
+Output
+    name	luvit
+    version	0.4.0
+]]--
+```
+
+## querystring.urlencode(str)
+
+Encodes a string to be used in the query part of a url. Spaces are encoded to plus (+) signs. Non alpha-numeric characters are encoded to their hexadecimal equivalent.
+
+### Example
+```lua
+local qs = require("querystring")
+
+local example = "this is a £test <to encode>"
+local encoded = qs.urlencode(example)
+
+print ("Encoded: ",encoded)
+
+--[[
+Output
+    Encoded: 	this+is+a+%C2%A3test+%3Cto+encode%3E
+]]--
+```
+
+## querystring.urldecode(str)
+
+Decodes a urlencoded string.
+
+### Example
+```lua
+local qs = require("querystring")
+
+local example = "this+is+a+%C2%A3test+%3Cto+encode%3E"
+local decoded = qs.urldecode(encoded)
+
+print ("Decoded: ",decoded)
+
+--[[
+Output
+    Decoded: 	this is a £test <to encode>
+]]--
+```

--- a/lib/luvit/querystring.lua
+++ b/lib/luvit/querystring.lua
@@ -16,8 +16,11 @@ limitations under the License.
 
 --]]
 
+---[[
+# Query String
 
--- querystring helpers
+Helper for parsing, encoding and decoding query strings
+---]]
 local querystring = {}
 
 local string = require('string')
@@ -29,6 +32,25 @@ local format = string.format
 local match = string.match
 local gmatch = string.gmatch
 
+
+---[[
+Encodes a string to be used in the query part of a url. Spaces are encoded to 
+plus (+) signs. Non alpha-numeric characters are encoded to their hexadecimal 
+equivalent.
+
+### Example
+```lua
+local qs = require("querystring")
+local example = "this is a £test <to encode>"
+local encoded = qs.urlencode(example)
+
+print ("Encoded: ",encoded)
+
+--[[
+Output
+    Encoded: 	this+is+a+%C2%A3test+%3Cto+encode%3E
+]]--
+```---]]
 function querystring.urldecode(str)
   str = gsub(str, '+', ' ')
   str = gsub(str, '%%(%x%x)', function(h)
@@ -38,6 +60,25 @@ function querystring.urldecode(str)
   return str
 end
 
+
+---[[
+Decodes a urlencoded string.
+
+### Example
+```lua
+local qs = require("querystring")
+
+local example = "this+is+a+%C2%A3test+%3Cto+encode%3E"
+local decoded = qs.urldecode(encoded)
+
+print ("Decoded: ",decoded)
+
+--[[
+Output
+    Decoded: 	this is a £test <to encode>
+]]--
+```
+---]]
 function querystring.urlencode(str)
   if str then
     str = gsub(str, '\n', '\r\n')
@@ -49,7 +90,41 @@ function querystring.urlencode(str)
   return str
 end
 
--- parse querystring into table. urldecode tokens
+---[[
+Parses a querystring, returning table of url decoded tokens.
+
+Optionally override the default separator ('&') and assignment ('=') characters.
+
+### Examples
+
+```lua
+local qs = require("querystring")
+
+local to_parse = "name=luvit&version=0.4.0"
+local parsed = qs.parse(to_parse)
+for i,v in pairs(parsed) do print(i,v) end
+
+--[[
+Output
+    name	luvit
+    version	0.4.0
+]]--
+```
+
+```lua
+local qs = require("querystring")
+
+local to_parse = "name==luvit||version==0.4.0"
+local parsed = qs.parse(to_parse, "||", "==")
+for i,v in pairs(parsed) do print(i,v) end
+
+--[[
+Output
+    name	luvit
+    version	0.4.0
+]]--
+```
+---]]
 function querystring.parse(str, sep, eq)
   if not sep then sep = '&' end
   if not eq then eq = '=' end


### PR DESCRIPTION
Updated lib/luvit/querystring.lua to include inline docs in GitHub
Markdown format. There are a couple of points about this discussed
below. Also included is a stand-alone document for the querystring
module, again in GitHub Markdown format.

Regarding the inline docs, I have chosen to demark them using a
triple dash block comment, i.e: ---[[ .... ---]]. This is so it is
easier to include code snippets in the docs, which themselves may
include block comments using the default double dash format.

This does work to some effect, however the current doc scraper misses
out the first doc block comment and I'm not sure why, also some stray
double dashes appear.
