### PR TITLE
Makefile: make clean misses zlib and lcrypto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,8 @@ clean:
 	${MAKE} -C ${YAJLDIR} clean
 	${MAKE} -C ${UVDIR} distclean
 	${MAKE} -C examples/native clean
+	-rm ${ZLIBDIR}/*.o
+	-rm ${CRYPTODIR}/src/lcrypto.o
 	rm -rf build bundle
 
 install: all


### PR DESCRIPTION
lcrypto and zlib do not have makefiles and are compiled up "by hand."
Ensure they get removed.
