### PR TITLE
allow the user to pass in a nil timer

### DIFF
--- a/lib/luvit/timer.lua
+++ b/lib/luvit/timer.lua
@@ -173,7 +173,9 @@ local function setInterval(period, callback, ...)
 end
 
 local function clearTimer(timer)
-  if not timer then return end
+  if not timer then
+    return
+  end
   if timer._onTimeout then
     timer._onTimeout = nil
     if timer.close then


### PR DESCRIPTION
When starting / stopping a shared interval-based service one often has code such as

```
timer.clearTimer(token)
token = timer.setInterval(s, fn)
```

I can appreciate that a non-timer object would through, but think that when passing nil should be okay.
