### PR TITLE
Don't call pauseNoRef whenn operating on a file which uses pure lua

### DIFF
--- a/lib/luvit/uv.lua
+++ b/lib/luvit/uv.lua
@@ -318,7 +318,11 @@ uv.createReadableStdioStream = function(fd)
 
   -- unref the event loop so that we don't block unless the user
   -- wants stdin. This follows node's logic.
-  stdin:pauseNoRef()
+  if fd_type ~= "FILE" then
+    -- fs.createReadStream returns iStream which is pure lua and doesn't have
+    -- pauseNoRef method
+    stdin:pauseNoRef()
+  end
 
   return stdin
 end


### PR DESCRIPTION
fs.createReadStream returns a ReadStream which inherits from a pure Lua version of Stream class which doesn't have `pauseNoRef` method.
