### PR TITLE
Ignore dirty submodules.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,24 +1,32 @@
 [submodule "deps/http-parser"]
 	path = deps/http-parser
 	url = https://github.com/joyent/http-parser.git
+  ignore = dirty
 [submodule "deps/uv"]
 	path = deps/uv
 	url = https://github.com/joyent/libuv.git
+  ignore = dirty
 [submodule "deps/luajit"]
 	path = deps/luajit
 	url = http://luajit.org/git/luajit-2.0.git
+  ignore = dirty
 [submodule "deps/yajl"]
 	path = deps/yajl
 	url = https://github.com/lloyd/yajl.git
+  ignore = dirty
 [submodule "deps/zlib"]
 	path = deps/zlib
 	url = https://github.com/luvit/zlib.git
+  ignore = dirty
 [submodule "deps/openssl"]
 	path = deps/openssl
 	url = https://github.com/luvit/openssl.git
+  ignore = dirty
 [submodule "deps/luacrypto"]
 	path = deps/luacrypto
 	url = http://github.com/luvit/luacrypto
+  ignore = dirty
 [submodule "tools/gyp"]
 	path = tools/gyp
 	url = https://github.com/luvit/gyp.git
+  ignore = dirty


### PR DESCRIPTION
Added ignore = dirty in .gitmodules to avoid for submodules to be listed as modified like below:

```
# Changes not staged for commit:
#   (use "git add <file>..." to update what will be committed)
#   (use "git checkout -- <file>..." to discard changes in working directory)
#   (commit or discard the untracked or modified content in submodules)
#
# modified:   deps/http-parser (untracked content)
# modified:   deps/openssl (untracked content)
# modified:   deps/uv (untracked content)
# modified:   deps/zlib (untracked content)
```

Found this solution at http://stackoverflow.com/questions/7993413/git-submodules-with-modified-and-untracked-content-why-and-how-to-remove-it/10215013#10215013
Disclaimer: I am not a git expert, so could you review this is an appropriate way?
