### PR TITLE
Only close stdin if its not already closed

### DIFF
--- a/lib/luvit/uv.lua
+++ b/lib/luvit/uv.lua
@@ -367,7 +367,9 @@ function Process:initialize(command, args, options)
     self.stderr:close()
   end)
   self:on('exit', function ()
-    self.stdin:close()
+    if self.stdin._closed ~= true then
+      self.stdin:close()
+    end
     self:close()
   end)
 


### PR DESCRIPTION
This allows 3rd party apps to close `stdin` themselves, previously we would error() out as a double close.
