### PR TITLE
Buffer: Several Improvements to Buffer interface;

### DIFF
--- a/lib/luvit/buffer.lua
+++ b/lib/luvit/buffer.lua
@@ -123,7 +123,7 @@ end
 
 -- X:MEMO~2012.08.25@kristate returns buffer contents up until first instance of bufOrString
 -- Very useful for binary protocols
-function Buffer:until(bufOrString, i)
+function Buffer:upuntil(bufOrString, i)
   local offset = i and i - 1 or 0
   local bufOrString_ctype = ffi.cast("unsigned char*", bufOrString)
   local found = ffi.C.memmem(self.ctype + offset, self.length - offset, bufOrString_ctype, #bufOrString)


### PR DESCRIPTION
After implementing some binary protocols, I decided to clean-up the Buffer module.
Some highlights include:
■ Buffer.meta:__len
Allow usage of length operator(#)

■ Buffer:copy
Allow copying direct copying into buffer via ffi.copy

■ Buffer:upuntil
returns buffer contents up until first instance of bufOrString (very useful for binary protocols)
