### PR TITLE
fix: SyncWriteStream in lib/luvit/fs.lua breaks _G.len

### DIFF
--- a/lib/luvit/fs.lua
+++ b/lib/luvit/fs.lua
@@ -363,7 +363,7 @@ function SyncWriteStream:initialize(fd)
 end
 
 function SyncWriteStream:write(chunk, callback)
-  len = fs.writeSync(self.fd, self.offset, chunk)
+  local len = fs.writeSync(self.fd, self.offset, chunk)
   self.offset = self.offset + len
   return len
 end


### PR DESCRIPTION
this fixes a small scope bug in fs.lua  ,

see

https://github.com/luvit/luvit/issues/286
