### PR TITLE
Object:extend now works as expected.

### DIFF
--- a/lib/luvit/core.lua
+++ b/lib/luvit/core.lua
@@ -112,9 +112,18 @@ Creates a new sub-class.
       self.h = h
     end
 ]]
+
 function Object:extend()
   local obj = self:create()
-  obj.meta = {__index = obj, super = self}
+  local meta = {}
+  -- move the meta methods defined in our ancestors meta into our own
+  --to preserve expected behavior in children (like __tostring, __add, etc)
+  for k, v in pairs(self.meta) do
+    meta[k] = v
+  end
+  meta.__index = obj
+  meta.super=self
+  obj.meta = meta
   return obj
 end
 

--- a/tests/test-object.lua
+++ b/tests/test-object.lua
@@ -26,9 +26,18 @@ local Foo = require('core').Object:extend()
 function Foo:initialize(bar)
   self.bar = bar
 end
+function Foo.meta.__tostring(table)
+	return tostring(table.bar)
+end
+
+local Baz = Foo:extend()
 
 local foo1 = Foo:new(1)
 local foo2 = Foo:new(1)
 assert(foo1 ~= foo2)
-assert(tostring(foo1) ~= tostring(foo2))
+assert(tostring(foo1) == tostring(foo2))
 assert(foo1.bar == foo2.bar)
+
+local msg = 'asd'
+local baz1 = Baz:new(msg)
+assert(tostring(baz1) == msg)


### PR DESCRIPTION
Object:extend previously failed for metamethods defined on table.meta.  These methods are now copied into the new objects meta where they will be set into the metatable.  A new test case has been added to verify this behavior.
