### PR TITLE
UID and GID management for POSIX

### DIFF
--- a/src/luv.c
+++ b/src/luv.c
@@ -73,7 +73,7 @@ static const luaL_reg luv_f[] = {
   {"spawn", luv_spawn},
   {"processKill", luv_process_kill},
   {"getpid", luv_getpid},
-#ifndef _MSC_VER
+#ifndef _WIN32
   {"getuid", luv_getuid},
   {"getgid", luv_getgid},
   {"setuid", luv_setuid},

--- a/src/luv_process.c
+++ b/src/luv_process.c
@@ -46,7 +46,7 @@ int luv_getpid(lua_State* L){
   return 1;
 }
 
-#ifndef _MSC_VER
+#ifndef _WIN32
 /* Retrieves User ID */
 int luv_getuid(lua_State* L){
   int uid = getuid();

--- a/src/luv_process.h
+++ b/src/luv_process.h
@@ -27,7 +27,7 @@
 int luv_spawn(lua_State* L);
 int luv_process_kill(lua_State* L);
 int luv_getpid(lua_State* L);
-#ifndef _MSC_VER
+#ifndef _WIN32
 int luv_getuid(lua_State* L);
 int luv_getgid(lua_State* L);
 int luv_setuid(lua_State* L);


### PR DESCRIPTION
I was missing functions for dropping privileges in luvit. It is just a native implementation, because luvit does not have a process module yet like in nodejs.  My test program:

local process = require("uv_native")

local uid = process.getuid()
local gid = process.getgid()

print("UID: " .. uid .. " GID: " .. gid )

process.setgid(1000)

uid = process.getuid()
gid = process.getgid()

print("UID: " .. uid .. " GID: " .. gid )

process.setuid(1000)

uid = process.getuid()
gid = process.getgid()

print("UID: " .. uid .. " GID: " .. gid )
