### PR TITLE
Fix broken stream reading.

### DIFF
--- a/src/luv_handle.c
+++ b/src/luv_handle.c
@@ -81,9 +81,7 @@ void luv_on_close(uv_handle_t* handle) {
   free(handle);
 }
 
-int luv_close (lua_State* L) {
-  uv_handle_t* handle = luv_checkudata(L, 1, "handle");
-/*  printf("close   \tlhandle=%p handle=%p\n", handle->data, handle);*/
+int luv__close(lua_State* L, uv_handle_t* handle) {
   if (uv_is_closing(handle)) {
     fprintf(stderr, "WARNING: Handle already closing \tlhandle=%p handle=%p\n", handle->data, handle);
     return 0;
@@ -91,6 +89,11 @@ int luv_close (lua_State* L) {
   uv_close(handle, luv_on_close);
   luv_handle_ref(L, handle->data, 1);
   return 0;
+}
+
+int luv_close (lua_State* L) {
+  uv_handle_t* handle = luv_checkudata(L, 1, "handle");
+  return luv__close(L, handle);
 }
 
 int luv_ref(lua_State* L) {

--- a/src/luv_handle.h
+++ b/src/luv_handle.h
@@ -36,6 +36,7 @@ uv_buf_t luv_on_alloc(uv_handle_t* handle, size_t suggested_size);
 
 void luv_on_close(uv_handle_t* handle);
 
+int luv__close(lua_State* L, uv_handle_t* handle);
 int luv_close (lua_State* L);
 int luv_set_handler(lua_State* L);
 

--- a/src/luv_stream.c
+++ b/src/luv_stream.c
@@ -43,9 +43,11 @@ void luv_on_read(uv_stream_t* handle, ssize_t nread, uv_buf_t buf) {
 
   } else {
     uv_err_t err = uv_last_error(luv_get_loop(L));
+
     if (err.code == UV_EOF) {
       luv_emit_event(L, "end", 0);
     } else {
+      luv__close(L, handle);
       luv_push_async_error(L, uv_last_error(luv_get_loop(L)), "on_read", NULL);
       luv_emit_event(L, "error", 1);
     }


### PR DESCRIPTION
As specified in uv/src/unix/stream.c, the user should call uv_close() in the read_cb under certain error conditions.  Not calling uv_close immediately causes an assertion error.
