### PR TITLE
luv_stream: call uv_close in error on_read

### DIFF
--- a/src/luv_stream.c
+++ b/src/luv_stream.c
@@ -46,6 +46,7 @@ void luv_on_read(uv_stream_t* handle, ssize_t nread, uv_buf_t buf) {
     if (err.code == UV_EOF) {
       luv_emit_event(L, "end", 0);
     } else {
+      uv_close(handle, NULL);
       luv_push_async_error(L, uv_last_error(luv_get_loop(L)), "on_read", NULL);
       luv_emit_event(L, "error", 1);
     }


### PR DESCRIPTION
according to the uv comments the callback needs to:

/\* Error. User should call uv_close(). */

So lets do that.

This is happening when luvit/virgo connects to a stud proxy that has nothing backing it... having a hard time reproducing with anything else.
