### PR TITLE
nameser.h on OpenBSD lives in the standard location.

### DIFF
--- a/src/luv_portability.h
+++ b/src/luv_portability.h
@@ -23,7 +23,7 @@
 #define getpid _getpid
 #endif
 
-#if defined(__OpenBSD__) || defined(__MINGW32__) || defined(_MSC_VER)
+#if defined(__MINGW32__) || defined(_MSC_VER)
 # include <nameser.h>
 #else
 # include <arpa/nameser.h>


### PR DESCRIPTION
So no need to special-case OpenBSD in src/luv_portability.h for the standard location of nameser.h.

On the other hand, this will need to be revisited as OpenBSD's nameser.h which is installed doesn't have a definition for ns_t.
So it should probably pull nameser.h in it from ares, although this may be an issue if luv_portability.h is installed (is this true?) and ares' nameser.h isn't around.

For now, I think this diff should be merged though.
