### PR TITLE
Revert "lib: tls: remove unused function"

### DIFF
--- a/lib/luvit/tls.lua
+++ b/lib/luvit/tls.lua
@@ -446,6 +446,10 @@ function CleartextStream:_pusher()
   return self.pair.ssl:clearOut()
 end
 
+function CleartextStream:shutdown(cb)
+  self:destroy()
+  if cb then cb() end
+end
 function CleartextStream:destroy()
   if self.socket and self._closing ~= true then
     self.socket:destroy()


### PR DESCRIPTION
This reverts commit 2c802f3551c48f69b826dafca6a13fc81d04d679.

It seems shutdown() is required because ClearText should act like a
regular socket >_<
