### PR TITLE
Mate the test-fs-truncate code in luvit to the code in node.js.  Open the ftruncate test file as "r+" just line node.js.

### DIFF
--- a/tests/test-fs-truncate.lua
+++ b/tests/test-fs-truncate.lua
@@ -43,7 +43,7 @@ assert(stat.size == 0)
 
 -- ftruncateSync
 FS.writeFileSync(filename, data)
-local fd = FS.openSync(filename, 'a')
+local fd = FS.openSync(filename, 'r+')
 
 stat = FS.statSync(filename)
 assert(stat.size == 1024 * 16)


### PR DESCRIPTION
...Then the truncate calls work.
