### PR TITLE
gitmodules: move to a mirror of luajit on github

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,7 @@
   ignore = dirty
 [submodule "deps/luajit"]
 	path = deps/luajit
-	url = http://luajit.org/git/luajit-2.0.git
+	url = https://github.com/luvit/luajit-2.0.git
   ignore = dirty
 [submodule "deps/yajl"]
 	path = deps/yajl


### PR DESCRIPTION
One of the build boxes we have building virgo and luvit got IP banned
for cloning luajit too much. Move to a mirror locally to be nice.
