### PR TITLE
lib: luvit: tls: copy _pull logic from node

### DIFF
--- a/lib/luvit/tls.lua
+++ b/lib/luvit/tls.lua
@@ -317,6 +317,10 @@ function CryptoStream:_pull()
   dbg('CryptoStream:_pull')
 
   while #self._pending > 0 do
+    if not self.pair.ssl then
+      return
+    end
+
     local tmp = table.remove(self._pending)
     local callback = table.remove(self._pendingCallbacks)
 


### PR DESCRIPTION
Copy this logic from node:

```
while (this._pending.length > 0) {
    if (!this.pair.ssl) break;
```

Backtrace

```
Runtime error: deps/luvit/lib/luvit/tls.lua:438: attempt to index field 'ssl' (a nil value)
stack traceback:
    deps/luvit/lib/luvit/tls.lua:438: in function '_puller'
    deps/luvit/lib/luvit/tls.lua:341: in function '_pull'
    deps/luvit/lib/luvit/tls.lua:574: in function 'cycle'
    deps/luvit/lib/luvit/tls.lua:234: in function 'done'
    [string "modules/core.lua"]:289: in function 'callback'
    [string "modules/core.lua"]:213: in function 'emit'
    deps/luvit/lib/luvit/net.lua:149: in function 'callback'
    [string "modules/core.lua"]:175: in function 'callback'
    [string "modules/core.lua"]:213: in function 'emit'
    [string "modules/uv.lua"]:50: in function <[string "modules/uv.lua"]:49>
    [C]: in function 'xpcall'
    [string "modules/virgo-init.lua"]:251: in function <[string "modules/virgo-init.lua"]:249>
    [C]: in function 'run'
    [string "modules/virgo-init.lua"]:446: in function <[string "modules/virgo-init.lua"]:440>
```
