### PR TITLE
windows: fix process spawning

### DIFF
--- a/src/luv_process.c
+++ b/src/luv_process.c
@@ -114,9 +114,9 @@ int luv_spawn(lua_State* L) {
   options.stdio[2].flags = UV_IGNORE;
   */
 
-  options.stdio[0].flags = UV_CREATE_PIPE | UV_WRITABLE_PIPE;
-  options.stdio[1].flags = UV_CREATE_PIPE | UV_READABLE_PIPE;
-  options.stdio[2].flags = UV_CREATE_PIPE | UV_READABLE_PIPE;
+  options.stdio[0].flags = UV_CREATE_PIPE | UV_READABLE_PIPE;
+  options.stdio[1].flags = UV_CREATE_PIPE | UV_WRITABLE_PIPE;
+  options.stdio[2].flags = UV_CREATE_PIPE | UV_WRITABLE_PIPE;
 
   /*
   TODO: Handle creating pipes


### PR DESCRIPTION
The meaning of UV_READABLE_PIPE and UV_WRITABLE_PIPE is defined from
the perspective of the child process. Luvit was using them in the wrong
way, which accidentally works on unix but not on windows.
