### PR TITLE
Handle the environment variable being changed out from under the reading...

### DIFF
--- a/src/lenv.c
+++ b/src/lenv.c
@@ -75,13 +75,18 @@ static int lenv_get(lua_State* L) {
 #ifdef _WIN32
   char* s = NULL;
   DWORD size;
-  size = GetEnvironmentVariable(name, 0, 0);
+  size = GetEnvironmentVariable(name, NULL, 0);
   if (size) {
+    DWORD ret_size;
     s = malloc(size);
     if (!s) {
       return luaL_error(L, "Malloc env get string variable failed.");
     }
-    GetEnvironmentVariable(name, s, size);
+    ret_size = GetEnvironmentVariable(name, s, size);
+    if (ret_size == 0 || ret_size >= size) {
+      free(s);
+      s = NULL;
+    }
   }
   lua_pushstring(L, s);
   free(s);


### PR DESCRIPTION
... thread.

This came as a response to https://github.com/bnoordhuis having concerns of a race condition between one thread changing the env data out from under another.

This solves the case of uninitialized data but is it enough?  Should the GetEnvironmentVariable call be looped on until it returns either 0 (no value) or a valid value < size (success)?
