### PR TITLE
wrap the tests in a shell script

### DIFF
--- a/test_shell_exec.sh
+++ b/test_shell_exec.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+PATH=/bin:$PATH
+
+tools/build.py test


### PR DESCRIPTION
wrap the tests in a shell script so that on a properly set up windows
build host (one with git for windows installed and *.sh files associated
with sh.exe).  this is needed when the tests rely on unix commands like
openssl.

fix for https://github.com/luvit/luvit/issues/398
