### PR TITLE
Remove warning on used uninitialized variable

### DIFF
--- a/src/luv_udp.c
+++ b/src/luv_udp.c
@@ -50,7 +50,7 @@ static void luv_on_udp_recv(uv_udp_t* handle,
                             uv_buf_t buf,
                             struct sockaddr* addr,
                             unsigned flags) {
-  int port;
+  int port = 0;
   char ip[INET6_ADDRSTRLEN];
 
   /* load the lua state and the userdata */


### PR DESCRIPTION
The default compilation makes the use of port an error because both
branches of the if have conditions.
