### PR TITLE
Add missing command to the build instructions in the README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -41,6 +41,7 @@ To use the gyp build system run:
 
 ```
 cd luvit
+git submodule update --init --recursive
 ./configure
 make -C out
 tools/build.py test


### PR DESCRIPTION
Configure script depends on `gyp` Python module which is included as a submodule so you can't run configure script before checking out the submodule.
