### PR TITLE
Fixes for ARM build

### DIFF
--- a/configure
+++ b/configure
@@ -95,9 +95,11 @@ def host_arch():
   if arch == 'unknown':
     arch = uname('-m')
 
+  if arch.startswith('arm'):
+      # handle arm, armv3l, armv6l, etc.
+      return 'arm'
+
   return {
-    'arm': 'arm',
-    'armv6l': 'arm',
     'x86': 'ia32',
     'i386': 'ia32',
     'i486': 'ia32',


### PR DESCRIPTION
This branch maps `armv6l` host architecture to `arm` so luvit compiles on Rasperry Pi.

There is still an issue with openssl which has been fixed in https://github.com/luvit/openssl/pull/4.
