### PR TITLE
Modify Response object to correctly propagate 'error' events from the underlying socket object

### DIFF
--- a/lib/luvit/http.lua
+++ b/lib/luvit/http.lua
@@ -845,6 +845,10 @@ function Response:initialize(socket)
   self.header_names = {}
   self.headers_sent = false
   self.socket = socket
+
+  self.socket:on('error', function(err)
+      self:emit('error', err)
+  end)
 end
 
 Response.auto_date = true

--- a/tests/test-http-response-error-propagation.lua
+++ b/tests/test-http-response-error-propagation.lua
@@ -1,0 +1,42 @@
+--[[
+
+Copyright 2012 The Luvit Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+--]]
+
+require('helper')
+
+local Emitter = require('core').Emitter
+local http = require('http')
+
+local errorsCaught = 0
+
+-- Mock socket object
+socket = Emitter:new()
+
+-- Verify that Response object correctly propagates errors from the underlying
+-- socket (e.g. EPIPE, ECONNRESET, etc.)
+res = http.Response:new(socket)
+res:on('error', function(err)
+  errorsCaught = errorsCaught + 1
+end)
+
+socket:emit('error', {})
+socket:emit('error', {})
+socket:emit('error', {})
+
+process:on('exit', function()
+  assert(errorsCaught == 3)
+end)


### PR DESCRIPTION
This is a second part of the fix for #429. 

It modifies `Response` object to correctly propagate `error` events (`EPIPE`, `ECONNRESET`, ...) from the underlying `socket` object.

It turns out that I was right in #429 and there were two problems. First one was `__POSIX__` not being defined which caused `SIGPIPE` signals to not be ignored. The other one is that `Response` object doesn't correctly propagate `error` events from the underlying socket object.

I haven't immediately noticed this after posix thing was fixed because I had local modifications with a fix so it worked for me.
