### PR TITLE
Emit "parse" error onthe request instead of the response object.

### DIFF
--- a/lib/luvit/http.lua
+++ b/lib/luvit/http.lua
@@ -784,7 +784,8 @@ function ClientRequest:onSocket(socket)
     local nparsed = self.parser:execute(chunk, 0, #chunk)
     -- If it wasn't all parsed then there was an error parsing
     if nparsed < #chunk then
-      response:emit("error", "parse error")
+      local err = Error:new('parse error')
+      self:emit("error", err)
     end
   end)
   socket:on('error', function(err)

--- a/tests/test-http-parse-error.lua
+++ b/tests/test-http-parse-error.lua
@@ -1,0 +1,69 @@
+--[[
+
+Copyright 2012 The Luvit Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+--]]
+
+require('helper')
+
+local net = require('net')
+local http = require('http')
+
+local PORT = process.env.PORT or 10081
+local HOST = '127.0.0.1'
+
+local running = false
+
+local caughtErrors = 0
+local gotParseError = false
+
+local server = net.createServer(function(client)
+  client:write('test')
+  client:destroy()
+end)
+
+server:listen(PORT, HOST, function()
+  running = true
+
+  local req = http.request({
+    host = HOST,
+    port = PORT,
+    path = '/'
+  }, function (res)
+  end)
+
+  req:on("error", function(err)
+    msg = tostring(err)
+
+    caughtErrors = caughtErrors + 1
+
+    if msg:find('parse error') then
+      gotParseError = true
+    end
+
+    if running then
+      running = false
+      req:destroy()
+      server:close()
+    end
+  end)
+
+  req:done()
+end)
+
+process:on('exit', function()
+  assert(caughtErrors == 2)
+  assert(gotParseError)
+end)


### PR DESCRIPTION
## Problem Description

Currently `parse error` is emitted on `Response` object. This doesn't work well if you use `http.request` method.

The problem is that `error` is emitted before `http.request` callback is called. This means you don't have a chance to add `error` handler to the response object which causes an unhandled error and crashes the process if you don't have `error` handler on the `process` object.

Code which reproduces it:

``` lua
local http = require('http')

local req = http.request({
  host = 'luvit.io',
  port = 22,
  path = '/'
}, function (res)
  res:on('error', function(err)
    msg = tostring(err)
    print('Error while receiving a response: ' .. msg)
  end)

  res:on('data', function (chunk)
    p('ondata', {chunk=chunk})
  end)
  res:on('end', function ()
    res:destroy()
  end)
end)

req:on('error', function(err)
  msg = tostring(err)
  print('Error while sending a request: ' .. msg)
end)

req:done()
```

Error

``` bash
luvit test.lua
"UNHANDLED ERROR"   "parse error"
/w/luvit/lib/luvit/core.lua:162: UNHANDLED ERROR. Define process:on('error', handler) to catch such errors
```

As you can see, I did add listener for the `error` event, but this doesn't make a difference since `error` is emitted before the callback is called (https://github.com/luvit/luvit/blob/master/lib/luvit/http.lua#L787, https://github.com/luvit/luvit/blob/master/lib/luvit/http.lua#L623).
## Proposed Solution

I've updated the code to emit this error on request instead of response object. This seems like a reasonable solution to me and works fine because you have access to the request object as soon as you call `http.request` which means you can add `error` handler early enough.
