### PR TITLE
npm support

### DIFF
--- a/lib/luvit/module.lua
+++ b/lib/luvit/module.lua
@@ -127,6 +127,7 @@ end
 local builtinLoader = package.loaders[1]
 local base_path = process.cwd()
 local libpath = process.execPath:match('^(.*)' .. path.sep .. '[^' ..path.sep.. ']+' ..path.sep.. '[^' ..path.sep.. ']+$') ..path.sep.. 'lib' ..path.sep.. 'luvit' ..path.sep
+local bundled_paths = {"modules", "node_modules"}
 function module.require(filepath, dirname)
   if not dirname then dirname = base_path end
 
@@ -177,13 +178,15 @@ function module.require(filepath, dirname)
   -- Bundled path modules
   local dir = dirname .. path.sep
   repeat
-    local full_path = path.join(dir, "modules", filepath)
-    local loader = loadModule(full_path)
-    if type(loader) == "function" then
-      return loader()
-    else
-      errors[#errors + 1] = loader
+    local loader
+    for _, bundled_path in ipairs(bundled_paths) do
+      local full_path = path.join(dir, bundled_path, filepath)
+      loader = loadModule(full_path)
+      if type(loader) == "function" then
+        return loader()
+      end
     end
+    errors[#errors + 1] = loader
     dir = path.dirname(dir)
   until dir == "."
 

--- a/tests/node_modules/moduleN/init.lua
+++ b/tests/node_modules/moduleN/init.lua
@@ -1,0 +1,4 @@
+p("moduleN")
+_G.num_loaded = _G.num_loaded + 1
+local moduleM = require("moduleM")
+return {"moduleN"}

--- a/tests/node_modules/moduleN/node_modules/moduleM/init.lua
+++ b/tests/node_modules/moduleN/node_modules/moduleM/init.lua
@@ -1,0 +1,3 @@
+p("moduleM")
+_G.num_loaded = _G.num_loaded + 1
+return {"moduleM"}

--- a/tests/test-require.lua
+++ b/tests/test-require.lua
@@ -30,13 +30,14 @@ local rm1_m2 = require("./modules/module1/module2")
 local rm2_m2 = require("./modules/module2/module2")
 local rm1sm1_m2 = require("./modules/module1/../module1/module2")
 local rm2sm2_m2 = require("./modules/module2/../module2/module2")
+local mNmM = require("moduleN")
 
 printStderr("require: " .. tostring(require))
 
 p(m1, m1_m2, m2_m2)
 p(rm1, rm1_m2, rm2_m2, rm1sm1_m2, rm2sm2_m2)
 p({num_loaded=num_loaded})
-assert(num_loaded == 3, "There should be exactly three modules loaded, there was " .. num_loaded)
+assert(num_loaded == 5, "There should be exactly five modules loaded, there was " .. num_loaded)
 assert(m1 == rm1 and m1_m2 == rm1_m2 and m2_m2 == rm2_m2, "Modules are not caching correctly")
 
 -- Test native addons


### PR DESCRIPTION
Make `require()` to load (pure lua) modules in a `node_modules`
subdirectory, so that these modules can be managed as npm packages.
`npm install` ftw!
