### PR TITLE
add listenerCount to Emitter

### DIFF
--- a/lib/luvit/core.lua
+++ b/lib/luvit/core.lua
@@ -197,6 +197,19 @@ function Emitter:on(name, callback)
   return self
 end
 
+function Emitter:listenerCount(name)
+  local handlers = rawget(self, "handlers")
+  if not handlers then
+    return 0
+  end
+  local handlers_for_type = rawget(handlers, name)
+  if not handlers_for_type then
+    return 0
+  else
+    return #handlers_for_type
+  end
+end
+
 -- Emit a named event to all listeners with optional data argument(s).
 function Emitter:emit(name, ...)
   local handlers = rawget(self, "handlers")

--- a/tests/test-emitter.lua
+++ b/tests/test-emitter.lua
@@ -19,6 +19,16 @@ limitations under the License.
 require("helper")
 
 --
+-- test listenerCount
+--
+assert(2 == require('core').Emitter:new()
+  :on("foo", function(a) end)
+  :on("foo", function(a,b) end)
+  :on("bar", function(a,b) end)
+  :listenerCount("foo"))
+assert(0 == require('core').Emitter:new():listenerCount("non-exist"))
+
+--
 -- chaining works
 --
 require('core').Emitter:new()


### PR DESCRIPTION
The `:listenerCount` method is needed in the stream interface. `node.js` had it implemented as `EventEmitter.listenerCount(emitter, name)` but it doesn't seem to make a difference in lua.
