### PR TITLE
Fix the path where libuv headers are installed

### DIFF
--- a/luvit.gyp
+++ b/luvit.gyp
@@ -264,7 +264,8 @@
               {
                 'destination': '<(luvit_prefix)/include/luvit/uv',
                 'files': [
-                  'deps/uv/include/'
+                  'deps/uv/include/uv-private',
+                  'deps/uv/include/uv.h'
                 ]
               },
               {


### PR DESCRIPTION
This was causing a mismatch between the output in `luvit --cflags` and the actual paths where the libuv headers were installed.
