### PR TITLE
when compiling on solaris, c99 features are needed

### DIFF
--- a/deps/yajl.gyp
+++ b/deps/yajl.gyp
@@ -29,6 +29,11 @@
         'yajl/src',
         '<(SHARED_INTERMEDIATE_DIR)',
       ],
+      'conditions': [
+        ['OS=="solaris"', {
+          'cflags': [ '--std=c99' ]
+        }]
+      ]
     }, # end libyajl
   {
     'target_name': 'copy_headers',


### PR DESCRIPTION
yajl uses the `isinf` function/macro which is not available on solaris when using c89. This patch forces yawl to compile using c99 features. However this patch does not fix building luvit without python support.

to build on solars run

```
./configure --arch=ia32
make -C out
```
