### PR TITLE
Restore basic language builtins

### DIFF
--- a/lib/luvit/luvit.lua
+++ b/lib/luvit/luvit.lua
@@ -184,13 +184,6 @@ process.stderr = uv.createWriteableStdioStream(2)
 -- This will break lua code written for other lua runtimes
 _G.io = nil
 _G.os = nil
-_G.math = nil
-_G.string = nil
-_G.coroutine = nil
-_G.jit = nil
-_G.bit = nil
-_G.debug = nil
-_G.table = nil
 _G.loadfile = nil
 _G.dofile = nil
 _G.print = utils.print


### PR DESCRIPTION
I regret removing these in the beginning.  It shouldn't break anything to add them back and it will make life easier for people coming from the lua side who are used to them being globals.

I am still leaving out things like `os`, `io`, `loadfile`, and `dofile` because they easily do process blocking I/O killing luvit performance.
