### PR TITLE
Fix: emit write stream "end" after closing the stream

### DIFF
--- a/lib/luvit/fs.lua
+++ b/lib/luvit/fs.lua
@@ -394,8 +394,8 @@ function SyncWriteStream:finish(chunk)
   if chunk then
     self:write(chunk)
   end
-  self:emit("end")
   self:_closeStream()
+  self:emit("end")
 end
 
 function SyncWriteStream:_closeStream()


### PR DESCRIPTION
- This fixes a race condition where the stream may still be open
  after end is emitted and handled
