### PR TITLE
fix(fs_call): memory leak

### DIFF
--- a/src/luv_fs.c
+++ b/src/luv_fs.c
@@ -225,6 +225,8 @@ uv_fs_t* luv_fs_store_callback(lua_State* L, int index) {
     }                                                                         \
     argc = luv_process_fs_result(L, req);                                 \
     lua_remove(L, -argc - 1);                                                 \
+    free(req->data);                                                          \
+    uv_fs_req_cleanup(req);                                                   \
     return argc;                                                              \
   } while (0)
 


### PR DESCRIPTION
@creationix @rjemanuele 

Fixes a memory leak on FS_CALL functions without a callback.
