### PR TITLE
Fix: Use-after-free and subsequent memory leaks

### DIFF
--- a/src/luv_fs.c
+++ b/src/luv_fs.c
@@ -214,8 +214,8 @@ uv_fs_t* luv_fs_store_callback(lua_State* L, int index) {
       if (uv_fs_##func(luv_get_loop(L), req, __VA_ARGS__, luv_after_fs)) {  \
         err = uv_last_error(luv_get_loop(L));                                 \
         luv_push_async_error(L, err, #func, path);                            \
-        free(req->data);                                                      \
         uv_fs_req_cleanup(req);                                                   \
+        free(req->data);                                                      \
         return lua_error(L);                                                  \
       }                                                                       \
       return 0;                                                               \
@@ -223,14 +223,14 @@ uv_fs_t* luv_fs_store_callback(lua_State* L, int index) {
     if (uv_fs_##func(luv_get_loop(L), req, __VA_ARGS__, NULL) < 0) {        \
       err = uv_last_error(luv_get_loop(L));                                 \
       luv_push_async_error(L, err, #func, path);                              \
-      free(req->data);                                                        \
       uv_fs_req_cleanup(req);                                                 \
+      free(req->data);                                                        \
       return lua_error(L);                                                    \
     }                                                                         \
     argc = luv_process_fs_result(L, req);                                 \
     lua_remove(L, -argc - 1);                                                 \
-    free(req->data);                                                          \
     uv_fs_req_cleanup(req);                                                   \
+    free(req->data);                                                          \
     return argc;                                                              \
   } while (0)
 


### PR DESCRIPTION
Freeing the FS request data seems to [free the request itself](https://github.com/luvit/luvit/blob/9bd578462c034b24b60af42b148061c5fad5c48b/src/luv_fs.c#L194-199), which messes with [the cleanup](https://github.com/joyent/libuv/blob/6e24ce23b1e7576059f85a608eca13b766458a01/src/win/fs.c#L1961) in libuv. This should fix it and allow it to deallocate the path properly.