### PR TITLE
http codec doesn't treat "" as nil in encodeHead.

### DIFF
--- a/modules/http-codec.lua
+++ b/modules/http-codec.lua
@@ -88,7 +88,7 @@ exports.encoder = function ()
   local encodeHead, encodeRaw, encodeChunked
 
   function encodeHead(item)
-    if not item then return end
+    if not item or item == "" then return end
     local head, chunkedEncoding
     local version = item.version or 1.1
     if item.method then

--- a/modules/http-codec.lua
+++ b/modules/http-codec.lua
@@ -88,7 +88,11 @@ exports.encoder = function ()
   local encodeHead, encodeRaw, encodeChunked
 
   function encodeHead(item)
-    if not item or item == "" then return end
+    if not item or item == "" then
+      return item
+    elseif not (type(item) == "table") then
+      error("expected a table but got a " .. type(item) .. " when encoding data")
+    end
     local head, chunkedEncoding
     local version = item.version or 1.1
     if item.method then


### PR DESCRIPTION
when replying to an http request like so `res:finish("")` it should have the same behavior as `res:finish()`. Right now it just crashes trying to get a status code from "".

This causes "" to be treated like nil.