### PR TITLE
done no longer ignores data being passed before the connections is established

### DIFF
--- a/deps/http.lua
+++ b/deps/http.lua
@@ -323,7 +323,7 @@ function ClientRequest:initialize(options, callback)
     end)
 
     if self.ended then
-      self:_done(nil, nil, self.ended)
+      self:_done(self.ended.data, self.ended.encoding, self.ended.cb)
     end
 
   end)
@@ -365,7 +365,10 @@ end
 function ClientRequest:done(data, encoding, cb)
   -- Send the data if connected otherwise just mark it ended
   self:flushHeaders()
-  self.ended = cb or function() end
+  self.ended = 
+    {cb = cb or function() end
+    ,data = data
+    ,encoding = encoding}
   if self.connected then
     self:_done(self.encode(data), encoding, cb)
   end


### PR DESCRIPTION
calling done before the connection was established causes the request to be sent without any data. This will save the data until the connection is established and then send it then.