### PR TITLE
expose package version in -v and --version

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -22,6 +22,7 @@ return require('./init')(function (...)
   local luvi = require('luvi')
   local uv = require('uv')
   local utils = require('utils')
+  local package = require('./package.lua')
 
   local startRepl = nil
   local combo = nil
@@ -46,7 +47,7 @@ return require('./init')(function (...)
   end
 
   local function version()
-    print("TODO: show luvit version")
+    print('luvit version: ' .. package.version)
     startRepl = false
   end
 


### PR DESCRIPTION
All this PR does is expose the `package.lua` version in the -v/--version flag. It follows the same convention as the `lit version` function.

```sh
$ luvit -v
luvit version: 1.9.5
$ lit version
lit version: 0.11.4
```

I figured reading the package would be nicer than hard-coding, since it's one less thing to bump when the version increments.