### PR TITLE
Luvit1: add no compression and release buffers to ssl context

### DIFF
--- a/src/luv_tls.c
+++ b/src/luv_tls.c
@@ -139,6 +139,7 @@ tls_sc_create(lua_State *L) {
   /* TODO: customize Session cache */
   SSL_CTX_set_session_cache_mode(ctx->ctx, SSL_SESS_CACHE_SERVER);
   SSL_CTX_set_options(ctx->ctx, SSL_OP_NO_COMPRESSION);
+  SSL_CTX_set_mode(ctx->ctx, SSL_MODE_RELEASE_BUFFERS);
 
   return 1;
 }

--- a/src/luv_tls.c
+++ b/src/luv_tls.c
@@ -138,6 +138,7 @@ tls_sc_create(lua_State *L) {
   ctx->ctx = SSL_CTX_new(method);
   /* TODO: customize Session cache */
   SSL_CTX_set_session_cache_mode(ctx->ctx, SSL_SESS_CACHE_SERVER);
+  SSL_CTX_set_options(ctx->ctx, SSL_OP_NO_COMPRESSION);
 
   return 1;
 }


### PR DESCRIPTION
Reference: https://journal.paul.querna.org/articles/2011/04/05/openssl-memory-use/