### PR TITLE
added cwd option to spawn

### DIFF
--- a/deps/childprocess.lua
+++ b/deps/childprocess.lua
@@ -97,6 +97,7 @@ local function spawn(command, args, options)
   end
 
   handle, pid = uv.spawn(command, {
+    cwd = options.cwd or nil,
     stdio = stdio,
     args = args,
     env = envPairs,


### PR DESCRIPTION
Add the ability to pass cwd in the options to childprocess.spawn.
It is already supported by uv.spawn