### PR TITLE
Fix obsolete instructions in the README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -29,21 +29,19 @@ cd luvit
 make
 ```
 
-If you want to test luvit without constantly building, set the magic `LUVI_APP` variable that makes **all** luvi binaries use a certain folder for the app bundle.  This is best done with a bash alias so as to not break other luvi based apps like `lit`.
+If you want to test luvit without constantly building, use `luvi`.
 
 ```sh
-alias luvit=LUVI_APP=`pwd`" "luvit
+luvi . 
 ```
-
-Also you can use `lit run` in the luvit root folder.
 
 Always make sure to run `make test` before submitting a PR.
 
 ## Notes to Maintainers
 
- - Use `LUVI_APP=/path/to/luvit luvit` to test changes without rebuilding the binary.
- - To run the test suite, either run `make test` to build a luvit and use that.
- - If you want to test a custom built luvi, run `LUVI_APP=. /path/to/luvi tests/run.lua`
+ - Use `luvi /path/to/luvit` to test changes without rebuilding the binary.
+ - To run the test suite, run `make test` to build a luvit and use that.
+ - If you want to test a custom built luvi, run `luvi . -- tests/run.lua`
  - There is a wiki page on making new luvit releases at <https://github.com/luvit/luvit/wiki/Making-a-luvit-release>.
 
 The packages in deps live primarily in this repo, but some are duplicated in


### PR DESCRIPTION
I'm not positive that all of my changes are ideal, so feel free to consider this a guide to what needs to be updated.

I'm the least confident about `luvi . -- tests/run.lua`. It works, but variants when `cwd` is not the luvit source directory will not.

```bat
H:\Programming\Lua\lit\luvit>luvi . -- tests/run.lua
...
# All tests passed

H:\>luvi H:\Programming\Lua\lit\luvit -- tests/run.lua
Uncaught exception:
[string "bundle:deps/require.lua"]:171: No such module 'H:\tests\run.lua' in 'bundle:main.lua'
stack traceback:
        [C]: in function 'error'
        [string "bundle:deps/require.lua"]:171: in function 'require'
        [string "bundle:main.lua"]:115: in function 'main'
        [string "bundle:/init.lua"]:34: in function <[string "bundle:/init.lua"]:32>
        [C]: in function 'xpcall'
        [string "bundle:/init.lua"]:32: in function <[string "bundle:/init.lua"]:20>

H:\>luvi H:\Programming\Lua\lit\luvit -- H:\Programming\Lua\lit\luvit\tests\run.lua
Uncaught exception:
[string "H:\Programming\Lua\lit\luvit\tests\run.lua"]:25: bad argument #1 to 'fs_scandir_next' (uv_req expected, got nil)
stack traceback:
        [C]: in function 'fs_scandir_next'
        [string "H:\Programming\Lua\lit\luvit\tests\run.lua"]:25: in function 'fn'
        [string "bundle:deps/require.lua"]:191: in function 'require'
        [string "bundle:main.lua"]:115: in function 'main'
        [string "bundle:/init.lua"]:34: in function <[string "bundle:/init.lua"]:32>
        [C]: in function 'xpcall'
        [string "bundle:/init.lua"]:32: in function <[string "bundle:/init.lua"]:20>

H:\>luvi H:\Programming\Lua\lit\luvit -m tests/run.lua
[string "bundle:tests/run.lua"]:25: bad argument #1 to 'fs_scandir_next' (uv_req expected, got nil)
```

Not sure if these errors are specific to Windows.