### PR TITLE
readline: Fix case where multiple control characters get entered at once

### DIFF
--- a/tests/test-readline.lua
+++ b/tests/test-readline.lua
@@ -1,0 +1,65 @@
+--[[
+
+Copyright 2015 The Luvit Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+--]]
+
+local readline = require('readline')
+local prettyPrint = require('pretty-print')
+local Editor = readline.Editor
+
+require('tap')(function(test)
+  test('readline Editor:onKey', function(expect)
+    local editor = Editor.new({
+      stdin = prettyPrint.stdin,
+      stdout = prettyPrint.stdout
+    })
+
+    -- need to call readLine to initialize some variables
+    editor:readLine("", function() end)
+    -- but don't want to actually read anything
+    editor.stdin:read_stop()
+    editor.stdin:set_mode(0)
+
+    -- starting position
+    assert(#editor.line == 0)
+    assert(editor.position == 1)
+
+    -- single key
+    editor:onKey('a')
+    assert(editor.line == "a")
+    assert(editor.position == 2)
+
+    -- left arrow
+    editor:onKey('\027[D')
+    assert(editor.line == "a")
+    assert(editor.position == 1)
+
+    -- multiple keys
+    editor:onKey('abc')
+    assert(editor.line == "abca")
+    assert(editor.position == 4)
+
+    -- multiple control sequences (left arrows)
+    editor:onKey('\027[D\027[D\027[D')
+    assert(editor.line == "abca")
+    assert(editor.position == 1)
+
+    -- mixture of characters and control sequences
+    editor:onKey('a\027[Db\027[Dc\027[Dd')
+    assert(editor.line == "dcbaabca")
+    assert(editor.position == 2)
+  end)
+end)


### PR DESCRIPTION
For example: 
```lua
'\027[D\027[D\027[D\027[D\027[D\027[D\027[D'
```

This PR makes readLine consume a key at a time instead of doing simple string comparisons against the whole input buffer

Note: There is still a lingering broken edge case when extremely large inputs are sent. If they are so large that the onKey call is broken up into multiple calls, then the cutoff point is arbitrary, meaning that it can end at something like '\027' and then the next call would start with '[D', which would then cause the trailing \027 to go unhandled and then the proceeding [D would be treated as normal characters and inserted into the Editor's line.

I was testing this using a strange method, as it just so happens that ConEmu sends massive amounts of arrow key presses if you click somewhere in the window that is far away from the cursor. It seems like it should be possible to add a test case for this, though, so let me know if you'd like me to do that.

EDIT: Went ahead and added test cases. Note that the last 4 asserts in the `readline Editor:onKey` test would have failed before this PR.