### PR TITLE
Refactor require to use shared prototype for module

### DIFF
--- a/deps/repl.lua
+++ b/deps/repl.lua
@@ -28,8 +28,10 @@ local History = require('readline').History
 setmetatable(exports, {
   __call = function (_, stdin, stdout, greeting)
 
+  local req, mod = require('require')(pathJoin(uv.cwd(), "repl"))
   local global = setmetatable({
-    require = require('require')(pathJoin(uv.cwd(), "repl"))
+    require = req,
+    module = mod,
   }, {
     __index = _G
   })


### PR DESCRIPTION
The `module` global in luvit's require system now has several methods.

## module:require(path)

This is the real implementation to require, the global `require` is just a closure binding to this method.

## module:load(path)

Load any asset as data.  Works relative to caller just like require.

## module:resolve(path)

Direct access to the module resolver logic.

## module:stat(path)

Stat any asset

## module:scan(path)

Get an iterator to walk any directory as assets.

The external interface to the require module has also changed slightly.  It now returns `require, module` when bootstrapping to give access to all the module methods.