### PR TITLE
avoid crash if nil string in http request:write()

### DIFF
--- a/deps/http.lua
+++ b/deps/http.lua
@@ -405,7 +405,7 @@ function ClientRequest:write(data, cb)
   local encoded = self.encode(data)
 
   -- Don't write empty strings to the socket, it breaks HTTPS.
-  if #encoded > 0 then
+  if encoded and #encoded > 0 then
     Writable.write(self, encoded, cb)
   else
     if cb then
@@ -480,4 +480,3 @@ function exports.get(options, onResponse)
   req:done()
   return req
 end
-


### PR DESCRIPTION
Hi,

It's just for add more safety in case of nil string/body.
Original exception:
```
Uncaught exception:
[string "bundle:deps/http.lua"]:407: attempt to get length of local 'encoded' (a nil value)
```
Thanks