### PR TITLE
Add headerMeta to make http headers smarter (fixes #773)

### DIFF
--- a/tests/test-headermeta.lua
+++ b/tests/test-headermeta.lua
@@ -1,0 +1,113 @@
+local headerMeta = require('http').headerMeta
+
+require('tap')(function(test)
+
+  test("Set via string", function()
+    local headers = setmetatable({}, headerMeta)
+    headers.Game = "Monkey Ball"
+    headers.Color = "Many"
+    p(headers)
+    assert(#headers == 2)
+    assert(headers.game == "Monkey Ball")
+    assert(headers.color == "Many")
+  end)
+
+  test("Set via append", function()
+    local headers = setmetatable({}, headerMeta)
+    headers[#headers + 1] = {"Game", "Monkey Ball"}
+    headers[#headers + 1] = {"Color", "Many"}
+    p(headers)
+    assert(#headers == 2)
+    assert(headers.game == "Monkey Ball")
+    assert(headers.color == "Many")
+  end)
+
+  test("Replace header", function()
+    local headers = setmetatable({}, headerMeta)
+    headers.Game = "Monkey Ball"
+    headers.Game = "Ultimate"
+    p(headers)
+    assert(#headers == 1)
+    assert(headers.game == "Ultimate")
+  end)
+
+  test("Duplicate Keys", function()
+    local headers = setmetatable({}, headerMeta)
+    headers[#headers + 1] = {"Skill", "Network"}
+    headers[#headers + 1] = {"Skill", "Compute"}
+    p(headers)
+    assert(#headers == 2)
+    assert(headers[1][2] == "Network")
+    assert(headers[2][2] == "Compute")
+    assert(headers.skill == "Network" or headers.skill == "Compute")
+  end)
+
+  test("Remove Keys", function()
+    local headers = setmetatable({
+      {"Color", "Blue"},
+      {"Color", "Red"},
+      {"Color", "Green"},
+    }, headerMeta)
+    p(headers)
+    assert(#headers == 3)
+    headers.color = nil
+    p(headers)
+    assert(#headers == 0)
+  end)
+
+  test("Replace Keys", function()
+    local headers = setmetatable({
+      {"Color", "Blue"},
+      {"Color", "Red"},
+      {"Color", "Green"},
+    }, headerMeta)
+    p(headers)
+    assert(#headers == 3)
+    headers.Color = "Orange"
+    p(headers)
+    assert(#headers == 1)
+    assert(headers.Color == "Orange")
+  end)
+
+  test("Replace Keys with Keys", function()
+    local headers = setmetatable({
+      {"Color", "Blue"},
+      {"Color", "Red"},
+      {"Color", "Green"},
+    }, headerMeta)
+    p(headers)
+    assert(#headers == 3)
+    headers.Color = { "Orange", "Purple" }
+    p(headers)
+    assert(#headers == 2)
+    assert(headers[1][2] == "Orange")
+    assert(headers[2][2] == "Purple")
+  end)
+
+  test("Large test", function()
+    local headers = setmetatable({
+      {"Game", "Monkey Ball"},
+      {"Game", "Ultimate"},
+      {"Skill", "Network"},
+      {"Skill", "Compute"},
+      {"Color", "Blue"},
+      {"Color", "Red"},
+      {"Color", "Green"},
+    }, headerMeta)
+    headers.Why = "Because"
+    p(headers)
+    assert(#headers == 8)
+    if headers.cOLOR then
+      headers.Color = "Many"
+    end
+    if headers.gAME then
+      headers.Game = "Yes"
+    end
+    p(headers)
+    assert(#headers == 5)
+    assert(headers.game == "Yes")
+    assert(headers.color == "Many")
+    assert(headers.why == "Because")
+  end)
+
+end)

--- a/tests/test-http-client-server.lua
+++ b/tests/test-http-client-server.lua
@@ -57,4 +57,3 @@ require('tap')(function(test)
     end)
   end)
 end)
-


### PR DESCRIPTION
This pulls in the magic metatable from weblit that makes working with headers much easier.

It's even better than the node API now.  You can do case-sensitive lookups and replacements of headers using simple key/value access.

```lua
-- Will add a new header header containing {"Content-Length", "100"}
-- It will also remove any pre-existing headers with the same name (case insensitive)
headers["Content-Length"] = 100

-- Here we can do a case-insensitive lookup of headers without having to lowercase our key.
if headers["Content-Length"] then
  -- do something
end
```

The internal storage is always a plain array with `{key, value}` entries.  The metatable handles everything else.

You can even replace several headers (of the same name) with several new headers (of the same name) at once by passing a table of strings as the value.

```lua
headers["Set-Cookie"] = {
  "one cookie",
  "another cookie",
  "more cookies"}
```
