### PR TITLE
Replace print() with stdout:write() in repl.lua.

### DIFF
--- a/deps/repl.lua
+++ b/deps/repl.lua
@@ -49,7 +49,7 @@ setmetatable(exports, {
   })
   global._G = global
 
-  if greeting then print(greeting) end
+  if greeting then stdout:write(greeting) end
 
   local c = utils.color
 
@@ -62,14 +62,15 @@ setmetatable(exports, {
     for i = 1, results.n do
       results[i] = utils.dump(results[i])
     end
-    print(table.concat(results, '\t'))
+    stdout:write(table.concat(results, '\t'))
   end
 
   local buffer = ''
 
   local function evaluateLine(line)
+    stdout:write("\x1b[0G");
     if line == "<3" or line == "♥" then
-      print("I " .. c("err") .. "♥" .. c() .. " you too!")
+      stdout:write("I " .. c("err") .. "♥" .. c() .. " you too!")
       return '>'
     end
     local chunk  = buffer .. line
@@ -92,7 +93,7 @@ setmetatable(exports, {
         end
       else
         -- error
-        print(results[1])
+        stdout:write(results[1])
       end
     else
 
@@ -101,7 +102,7 @@ setmetatable(exports, {
         buffer = chunk .. '\n'
         return '>> '
       else
-        print(err)
+        stdout:write(err)
         buffer = ''
       end
     end
@@ -168,6 +169,8 @@ setmetatable(exports, {
       coroutine.wrap(function ()
         if line then
           prompt = evaluateLine(line)
+          stdout:write("\x1b[0G\n");
+          editor.position = 1
           editor:readLine(prompt, onLine)
           -- TODO: break out of >> with control+C
         elseif onSaveHistoryLines then

--- a/deps/repl.lua
+++ b/deps/repl.lua
@@ -62,15 +62,14 @@ setmetatable(exports, {
     for i = 1, results.n do
       results[i] = utils.dump(results[i])
     end
-    stdout:write(table.concat(results, '\t'))
+    stdout:write("\r" .. table.concat(results, '\t'))
   end
 
   local buffer = ''
 
   local function evaluateLine(line)
-    stdout:write("\x1b[0G");
     if line == "<3" or line == "♥" then
-      stdout:write("I " .. c("err") .. "♥" .. c() .. " you too!")
+      stdout:write("\rI " .. c("err") .. "♥" .. c() .. " you too!")
       return '>'
     end
     local chunk  = buffer .. line
@@ -93,7 +92,7 @@ setmetatable(exports, {
         end
       else
         -- error
-        stdout:write(results[1])
+        stdout:write("\r" .. string.gsub(results[1], "\n", "\n\r"))
       end
     else
 
@@ -102,7 +101,7 @@ setmetatable(exports, {
         buffer = chunk .. '\n'
         return '>> '
       else
-        stdout:write(err)
+        stdout:write("\r" .. err)
         buffer = ''
       end
     end
@@ -169,7 +168,7 @@ setmetatable(exports, {
       coroutine.wrap(function ()
         if line then
           prompt = evaluateLine(line)
-          stdout:write("\x1b[0G\n");
+          stdout:write("\n\r");
           editor.position = 1
           editor:readLine(prompt, onLine)
           -- TODO: break out of >> with control+C

--- a/deps/repl.lua
+++ b/deps/repl.lua
@@ -49,7 +49,7 @@ setmetatable(exports, {
   })
   global._G = global
 
-  if greeting then stdout:write(greeting) end
+  if greeting then stdout:write(greeting .. '\n') end
 
   local c = utils.color
 
@@ -62,14 +62,14 @@ setmetatable(exports, {
     for i = 1, results.n do
       results[i] = utils.dump(results[i])
     end
-    stdout:write("\r" .. table.concat(results, '\t'))
+    stdout:write(table.concat(results, '\t') .. '\n')
   end
 
   local buffer = ''
 
   local function evaluateLine(line)
     if line == "<3" or line == "♥" then
-      stdout:write("\rI " .. c("err") .. "♥" .. c() .. " you too!")
+      stdout:write("I " .. c("err") .. "♥" .. c() .. " you too!\n")
       return '>'
     end
     local chunk  = buffer .. line
@@ -92,7 +92,7 @@ setmetatable(exports, {
         end
       else
         -- error
-        stdout:write("\r" .. string.gsub(results[1], "\n", "\n\r"))
+        stdout:write(results[1] .. '\n')
       end
     else
 
@@ -101,7 +101,7 @@ setmetatable(exports, {
         buffer = chunk .. '\n'
         return '>> '
       else
-        stdout:write("\r" .. err)
+        stdout:write(err .. '\n')
         buffer = ''
       end
     end
@@ -168,8 +168,6 @@ setmetatable(exports, {
       coroutine.wrap(function ()
         if line then
           prompt = evaluateLine(line)
-          stdout:write("\n\r");
-          editor.position = 1
           editor:readLine(prompt, onLine)
           -- TODO: break out of >> with control+C
         elseif onSaveHistoryLines then


### PR DESCRIPTION
This allows the REPL to be hooked up to e.g. a JavaScript vt100 terminal via
WebSockets; without this change you can type into the terminal and each line
will be evaluated, but no output is sent back.

It then became trivial to hook up term.js to a WebSocket served by weblit-websocket.  This is the websocket handler I wrote (for example only, not production-quality):

```lua
local uv = require('uv')

-- This is called every time a new WebSocket client connects.
return function (req, read, write)
  stdout = {}
  function stdout:write (data)
    write({
      opcode = 1,
      payload = data
    })
  end

  stdin = { callback = nil, buffer = "" }
  function stdin:read_start (read_callback)
    self.callback = read_callback
    for i = 1, self.buffer:len() do
      self.callback(self.buffer:sub(i,i))
    end
    self.buffer = ""
  end
  function stdin:read_stop ()
    self.callback = nil
  end
  function stdin:set_mode (mode)
    -- TODO: don't know the intended semantics of set_mode...
    -- must read more about uv_tty_set_mode()
  end

  greeting = "Welcome to the REPL!!"
  function saveHistory (lines)
    print "saveHistory not implemented"
    write()
  end
  bogusInitialHistory = "these are the lines\nhere is a second line\n2 + 2 * 4\ninvokeFunction()"

  repl = require('repl')(stdin, stdout, greeting)
  repl.start(bogusInitialHistory, saveHistory)

  for message in read do
    if stdin.callback then
      stdin.callback(nil, message.payload)
    else
      stdin.buffer = stdin.buffer .. message.payload
      print("buffering: " .. stdin.buffer)
    end
  end

  print("about to do final write message ===========================?");
  write()
end
```