### PR TITLE
http: Fix duplication of host/connection/user-agent request headers

### DIFF
--- a/deps/http.lua
+++ b/deps/http.lua
@@ -364,9 +364,9 @@ function ClientRequest:initialize(options, callback)
     self[#self + 1] = headers[i]
     local key, value = unpack(headers[i])
     local klower = key:lower()
-    host_found = host_found or (klower == 'host' and value)
-    connection_found = connection_found or (klower == 'connection' and value)
-    user_agent = user_agent or (klower == 'user-agent' and value)
+    if klower == 'host' then host_found = value end
+    if klower == 'connection' then connection_found = value end
+    if klower == 'user-agent' then user_agent = value end
   end
 
   if not user_agent then

--- a/deps/http.lua
+++ b/deps/http.lua
@@ -371,10 +371,10 @@ function ClientRequest:initialize(options, callback)
 
   if not user_agent then
     user_agent = self.getDefaultUserAgent()
-  end
 
-  if user_agent ~= '' then
-    table.insert(self, 1, { 'User-Agent', user_agent })
+    if user_agent ~= '' then
+      table.insert(self, 1, { 'User-Agent', user_agent })
+    end
   end
 
   if not host_found and options.host then

--- a/deps/http.lua
+++ b/deps/http.lua
@@ -364,9 +364,9 @@ function ClientRequest:initialize(options, callback)
     self[#self + 1] = headers[i]
     local key, value = unpack(headers[i])
     local klower = key:lower()
-    host_found = klower == 'host' and value
-    connection_found = klower == 'connection' and value
-    user_agent = klower == 'user-agent' and value
+    host_found = host_found or (klower == 'host' and value)
+    connection_found = connection_found or (klower == 'connection' and value)
+    user_agent = user_agent or (klower == 'user-agent' and value)
   end
 
   if not user_agent then


### PR DESCRIPTION
Caused when the passed in headers have multiple keys, causing each `found` variable to depend on the iteration order of the headers table (each `found` var would only care about the last header iterated)

Example reproduction:

```lua
    local headers = { {"Front", "test"}, {"Host", "luvit.io"}, {"Behind", "test"} }
    local request = http.request({host="luvit.io", headers=headers})
    request:destroy()
    local num_hosts = 0
    for i,v in ipairs(request) do
      p(i, v)
      if v[1]:lower() == "host" then
        num_hosts = num_hosts + 1
      end
    end
    assert(num_hosts == 1)
```