### PR TITLE
querystring: Add stringify

### DIFF
--- a/deps/querystring.lua
+++ b/deps/querystring.lua
@@ -50,6 +50,30 @@ function exports.urlencode(str)
   return str
 end
 
+local function stringifyPrimitive(v)
+  return tostring(v)
+end
+
+function exports.stringify(params, sep, eq)
+  if not sep then sep = '&' end
+  if not eq then eq = '=' end
+  if type(params) == "table" then
+    local fields = {}
+    for key,value in pairs(params) do
+      local keyString = exports.urlencode(stringifyPrimitive(key)) .. eq
+      if type(value) == "table" then
+        for _, v in ipairs(value) do
+          table.insert(fields, keyString .. exports.urlencode(stringifyPrimitive(v)))
+        end
+      else
+        table.insert(fields, keyString .. exports.urlencode(stringifyPrimitive(value)))
+      end
+    end
+    return table.concat(fields, sep)
+  end
+  return ''
+end
+
 -- parse querystring into table. urldecode tokens
 function exports.parse(str, sep, eq)
   if not sep then sep = '&' end

--- a/deps/querystring.lua
+++ b/deps/querystring.lua
@@ -43,10 +43,9 @@ end
 function exports.urlencode(str)
   if str then
     str = gsub(str, '\n', '\r\n')
-    str = gsub(str, '([^%w ])', function(c)
+    str = gsub(str, '([^%w])', function(c)
       return format('%%%02X', byte(c))
     end)
-    str = gsub(str, ' ', '+')
   end
   return str
 end

--- a/tests/test-querystring.lua
+++ b/tests/test-querystring.lua
@@ -1,22 +1,39 @@
-local parse = require('querystring').parse
+local qs = require('querystring')
 local deepEqual = require('deep-equal')
 
 require('tap')(function(test)
-  test('querystring', function(expect)
-    -- Basic code coverage
-    local tests = {
-      [{'%25 %20+=foo%25%00%41bar&a=%26%3db'}] = {['%   '] = 'foo%\000Abar', a = '&=b'},
-      [{'%25 %20+=foo%25%00%41bar&a=%26%3db', '+'}] = {['%  '] = '', ['']='foo%\000Abar&a=&=b'},
-      [{'f'}] = {f=''},
-      [{'f>u+u>f', '+', '>'}] = {f='u', u='f'},
-    }
+  -- Basic code coverage
+  -- format: { arbitraryQS, canonicalQS, parsedQS, sep, eq }
+  local tests = {
+    {'foo=1&bar=2', 'foo=1&bar=2', {['foo'] = '1', ['bar'] = '2'}},
+    {'%25 %20+=foo%25%00%41bar&a=%26%3db', '%25%20%20%20=foo%25%00Abar&a=%26%3Db', {['%   '] = 'foo%\000Abar', a = '&=b'}},
+    {'%25 %20+=foo%25%00%41bar&a=%26%3db', '=foo%25%00Abar%26a%3D%26%3Db+%25%20%20=', {['%  '] = '', ['']='foo%\000Abar&a=&=b'}, '+'},
+    {'f', 'f=', {f=''}},
+    {'f>u+u>f', 'f>u+u>f', {u='f', f='u'}, '+', '>'},
+  }
 
-    for input, output in pairs(tests) do
-      local tokens = parse(input[1], input[2], input[3])
+  test('parse', function(expect)
+    for num, test in ipairs(tests) do
+      local input = test[1]
+      local output = test[3]
+      local tokens = qs.parse(input, test[4], test[5])
       if not deepEqual(output, tokens) then
         p("Expected", output)
         p("But got", tokens)
-        error("Test failed " .. input[1])
+        error("Test failed: " .. input)
+      end
+    end
+  end)
+
+  test('stringify', function(expect)
+    for num, test in ipairs(tests) do
+      local input = test[3]
+      local output = test[2]
+      local str = qs.stringify(input, test[4], test[5])
+      if not deepEqual(output, str) then
+        p("Expected", output)
+        p("But got", str)
+        error("Test #" .. num .. " failed")
       end
     end
   end)


### PR DESCRIPTION
From the various commit messages:

- I changed urlencode to encode spaces as '%20' instead of '+'. This matches the behavior of Javascript's encodeURIComponent, which is what node.js uses.
- Implementation partially based on https://github.com/luvitrocks/luvit-querystring
- Node's implementation for reference: https://github.com/joyent/node/blob/master/lib/querystring.js

Note about the tests:

Iteration order of tables is arbitrary, so the stringify tests with multiple keys is a bit dubious whether or not they will always succeed, as the order could potentially be different.
I ordered the keys in the way that they are outputted on my system, but some safety might be required to make sure the tests succeed on every system