### PR TITLE
add versions of luvi options

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -49,6 +49,9 @@ return require('./init')(function (...)
   local function version()
     print('luvit version: ' .. package.version)
     print('luvi version: ' .. require('luvi').version)
+    for k, v in pairs(require('luvi').options) do
+      print(k .. ' version: ' .. v)
+    end
     startRepl = false
   end
 


### PR DESCRIPTION
Sample output:
```
# luvit -v
luvit version: 2.5.1
luvi version: v2.3.1
rex version: 8.37 2015-04-28
libuv version: 1.7.1
ssl version: OpenSSL 1.0.2d 9 Jul 2015, lua-openssl 0.4.1
```