### PR TITLE
fix(deps/dns.lua): resolv.conf parser enhancements

### DIFF
--- a/deps/dns.lua
+++ b/deps/dns.lua
@@ -745,8 +745,8 @@ exports.loadResolver = function(options)
   local posa = 1
 
   local function parse(line)
-    if not line:match('^#') then
-      local ip = line:match('nameserver%s(.*)')
+    if not (line:match('^#') or line:match('^;'))  then
+      local ip = line:match('^nameserver%s([a-fA-F0-9:\\.]+)')
       if ip then
         local server = {}
         server.host = ip

--- a/tests/fixtures/resolve.conf.a
+++ b/tests/fixtures/resolve.conf.a
@@ -1,3 +1,8 @@
 ## Comment
+; Another comment
+notnameserver 2001:db8::a
 nameserver 192.168.0.1
+somegarbage
 nameserver ::1
+nameserver notanip
+nameserver ::2 

--- a/tests/test-dns.lua
+++ b/tests/test-dns.lua
@@ -99,9 +99,10 @@ require('tap')(function (test)
       return
     end
     local servers = dns.loadResolver({ file = path.join(module.dir, 'fixtures', 'resolve.conf.a')})
-    assert(#servers > 0)
+    assert(#servers == 3)
     assert(servers[1].host == '192.168.0.1')
     assert(servers[2].host == '::1')
+    assert(servers[3].host == '::2')
     dns.setDefaultServers()
   end)
 end)


### PR DESCRIPTION
This changes the parser so that it:
- ignores whitespaces at end of line
- treats lines starting with ';' as comments
- expects keywords to start at the beginning of the line.

From man resolv.conf:
Lines that contain a semicolon (;) or hash character (#) in the first column are treated as comments.
The keyword and value must appear on a single line, and the keyword (e.g., nameserver) must start the line.  The value follows the keyword, separated by white space.