### PR TITLE
fix(repl)

### DIFF
--- a/deps/repl.lua
+++ b/deps/repl.lua
@@ -37,7 +37,7 @@ local _builtinLibs = { 'buffer', 'childprocess', 'codec', 'core',
   'dgram', 'dns', 'fs', 'helpful', 'hooks', 'http-codec', 'http',
   'https', 'json', 'los', 'net', 'pretty-print', 'process',
   'querystring', 'readline', 'timer', 'url', 'utils',
-  'stream', 'tls'
+  'stream', 'tls', 'path'
 }
 
 setmetatable(exports, {


### PR DESCRIPTION
Add path to the list of auto populated libs available to the user
My bad, guess I missed it somehow last time when I implemented the auto requires. 