### PR TITLE
Fix tests to mostly run in new luvi

### DIFF
--- a/deps/tls/common.lua
+++ b/deps/tls/common.lua
@@ -393,9 +393,9 @@ end
 exports.TLSSocket = TLSSocket
 
 -------------------------------------------------------------------------------
-local VERIFY_PEER = { "peer" }
-local VERIFY_PEER_FAIL = { "peer", "fail_if_no_peer_cert" }
-local VERIFY_NONE = { "none" }
+local VERIFY_PEER = openssl.ssl.peer
+local VERIFY_PEER_FAIL = openssl.ssl.fail
+local VERIFY_NONE = openssl.ssl.none
 
 exports.createCredentials = function(options, context)
   local ctx, returnOne

--- a/tests/test-tls-remote.lua
+++ b/tests/test-tls-remote.lua
@@ -26,6 +26,7 @@ require('tap')(function (test)
   p(options)
   local server
   local c
+  local openssl = require('openssl')
   print(openssl.error(true))
   test("tls remote-address", function()
     server = tls.createServer(options, function(s,err)


### PR DESCRIPTION
This branch is for testing luvit with the new in-progress luvi release.

The updates to lua-openssl seems to have broken some stuff.

To test this, use latest luvi from master instead of stable luvi.