### PR TITLE
Enable --256-colors if $TERM = *-256color

### DIFF
--- a/deps/pretty-print.lua
+++ b/deps/pretty-print.lua
@@ -325,7 +325,7 @@ if uv.guess_handle(1) == 'tty' then
   if width == 0 then width = 80 end
   -- auto-detect when 16 color mode should be used
   local term = env.get("TERM")
-  if term == 'xterm' or term == 'xterm-256color' then
+  if term == 'xterm' or term:match'-256color$' then
     defaultTheme = 256
   else
     defaultTheme = 16


### PR DESCRIPTION
This patch enables 256 colours for all terminals claiming to support it (e.g. TERM=screen-256color)