### PR TITLE
upgrade to support newest lua-openssl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 APP_FILES=$(shell find . -type f -name '*.lua')
 BIN_ROOT=lit/luvi-binaries/$(shell uname -s)_$(shell uname -m)
-LIT_VERSION=2.2.22
+LIT_VERSION=2.3.0
 
 LUVIT_TAG=$(shell git describe)
 LUVIT_ARCH=$(shell uname -s)_$(shell uname -m)

--- a/deps/tls/common.lua
+++ b/deps/tls/common.lua
@@ -393,9 +393,9 @@ end
 exports.TLSSocket = TLSSocket
 
 -------------------------------------------------------------------------------
-local VERIFY_PEER = { "peer" }
-local VERIFY_PEER_FAIL = { "peer", "fail_if_no_peer_cert" }
-local VERIFY_NONE = { "none" }
+local VERIFY_PEER = openssl.ssl.peer
+local VERIFY_PEER_FAIL = bit.bor(openssl.ssl.peer,openssl.ssl.fail)
+local VERIFY_NONE = openssl.ssl.none
 
 exports.createCredentials = function(options, context)
   local ctx, returnOne

--- a/deps/tls/init.lua
+++ b/deps/tls/init.lua
@@ -17,7 +17,7 @@ limitations under the License.
 --]]
 
 exports.name = "luvit/tls"
-exports.version = "1.3.2"
+exports.version = "1.3.3"
 exports.dependencies = {
   "luvit/core@1.0.5",
   "luvit/net@1.2.0",

--- a/make.bat
+++ b/make.bat
@@ -1,5 +1,5 @@
 @ECHO off
-@SET LIT_VERSION=2.2.22
+@SET LIT_VERSION=2.3.0
 
 IF NOT "x%1" == "x" GOTO :%1
 

--- a/package.lua
+++ b/package.lua
@@ -45,7 +45,7 @@ return {
     "luvit/stream@1.1.0",
     "luvit/thread@0.1.2",
     "luvit/timer@1.0.0",
-    "luvit/tls@1.3.1",
+    "luvit/tls@1.3.3",
     "luvit/utils@1.0.0",
     "luvit/url@1.0.4",
   },

--- a/package.lua
+++ b/package.lua
@@ -1,8 +1,8 @@
 return {
   name = "luvit/luvit",
-  version = "2.7.0",
+  version = "2.7.1",
   luvi = {
-    version = "2.4.0",
+    version = "2.5.0",
     flavor = "regular",
   },
   license = "Apache 2",

--- a/tests/test-tls-peer-certificate.lua
+++ b/tests/test-tls-peer-certificate.lua
@@ -53,7 +53,7 @@ require('tap')(function (test)
           --print('ERROR',err)
           local peercert = assert(socket:getPeerCertificate())
           peercert = peercert:parse()
-          assert(tostring(peercert.subject) == '/CN=alice/subjectAltName=uniformResourceIdentifier:http://localhost:8000/alice.foaf#me')
+          assert(peercert.subject:tostring() == '/CN=alice/subjectAltName=uniformResourceIdentifier:http://localhost:8000/alice.foaf#me')
           verified = true
           socket:destroy()
           server:close()

--- a/tests/test-tls-remote.lua
+++ b/tests/test-tls-remote.lua
@@ -17,6 +17,7 @@ limitations under the License.
 
 require('tap')(function (test)
   local fixture = require('./fixture-tls')
+  local openssl = require('openssl')
   local tls = require('tls')
 
   local options = {


### PR DESCRIPTION
Recreating the PR. coro-tls needs a bump as well.