### PR TITLE
When requiring a module, allow it to mutate the global namespace.

### DIFF
--- a/deps/require.lua
+++ b/deps/require.lua
@@ -289,7 +289,7 @@ function Module:require(name)
         return module:require(...)
       end
     }
-    setfenv(fn, setmetatable(global, { __index = _G, __newindex = _G }))
+    setfenv(fn, setmetatable(global, { __index = _G, __newindex = _G })) 
     local ret = fn()
 
     -- Allow returning the exports as well

--- a/deps/require.lua
+++ b/deps/require.lua
@@ -289,7 +289,7 @@ function Module:require(name)
         return module:require(...)
       end
     }
-    setfenv(fn, setmetatable(global, { __index = _G }))
+    setfenv(fn, setmetatable(global, { __index = _G, __newindex = _G }))
     local ret = fn()
 
     -- Allow returning the exports as well


### PR DESCRIPTION
Closes #857.

This PR modifies `luvit/deps/require.lua`:  All modules now share a global namespace. 

Consider the following module `foo.lua`:

```lua
x = 42
```

And the following module `bar.lua`:

```lua
require("foo")
print(x)
```

Now consider `require("bar")`.  Using standard Lua or LuaJIT, this causes `foo.lua` to be required, which sets `_G.x` to `42`, then ultimately prints `42` to stdout.

However, using Luvit's `require`, no mutations to `_G` were allowed.  Therefore `print(x)` would print `nil`.

I understand that there may be an argument for isolating each module in this manner.  Unfortunately, [Lumen](https://github.com/sctb/lumen) is designed to rely on the fact that requiring a module mutates the global state.  Since I'm trying to add `luvit` support to Lumen, this puts me in something of a tricky position.

I was hoping that you'd be willing to accept this PR (which is all that's needed for me to be able to support `luvit` in Lumen).  

For what it's worth, this PR does not break any tests in the test suite.  `make test` results in "All tests passed."

Either way, thanks for considering this.  Have a great week!

