### PR TITLE
Add url.format

### DIFF
--- a/deps/http.lua
+++ b/deps/http.lua
@@ -382,6 +382,8 @@ function ClientRequest:initialize(options, callback)
     end
   end
 
+  options.host = host_found or options.hostname or options.host
+
   if not host_found and options.host then
     table.insert(self, 1, { 'Host', options.host })
   end

--- a/deps/url.lua
+++ b/deps/url.lua
@@ -78,8 +78,6 @@ local function parse(url, parseQueryString)
   url = url:sub((host and #host or 0) + 1)
   end
 
-  host = hostname -- Just to be compatible with our code base. Discuss this.
-
   local path
   local pathname
   local search
@@ -146,20 +144,9 @@ local function format(parsed)
     host = auth .. parsed.host
   elseif parsed.hostname and parsed.hostname ~= "" then
     host = auth .. parsed.hostname
-  end
-  -- extract port from host if possible
-  -- note: url.parse does not include the port in the host key, so
-  -- extracting the port here is just for convenience
-  if host then
-    host = string.gsub(host, "(:%d+)$", function(hostPort)
-      if not port then
-        port = string.sub(hostPort, 2)
-      end
-      return ""
-    end)
-  end
-  if host and port then
-    host = host .. ':' .. port
+    if port then
+      host = host .. ':' .. port
+    end
   end
 
   if parsed.query and type(parsed.query) == "table" then

--- a/deps/url.lua
+++ b/deps/url.lua
@@ -29,6 +29,34 @@ limitations under the License.
 
 local querystring = require('querystring')
 
+local URL = {}
+
+local function encodeAuth(str)
+  if str then
+    str = string.gsub(str, '\n', '\r\n')
+    str = string.gsub(str, '([^%w:!-.~\'()*])', function(c)
+      return string.format('%%%02X', string.byte(c))
+    end)
+  end
+  return str
+end
+
+-- add the prefix if it doesnt already exist
+local function conditionallyPrefix(str, prefix)
+  if str and str ~= "" and string.sub(str, 1, #prefix) ~= prefix then
+    str = prefix .. str
+  end
+  return str
+end
+
+-- add the suffix if it doesnt already exist
+local function conditionallySuffix(str, suffix)
+  if str and str ~= "" and string.sub(str, -(#suffix)) ~= suffix then
+    str = str .. suffix
+  end
+  return str
+end
+
 local function parse(url, parseQueryString)
   local href = url
   local chunk, protocol = url:match("^(([a-z0-9+]+)://)")
@@ -83,8 +111,7 @@ local function parse(url, parseQueryString)
     query = querystring.parse(query)
   end
 
-  return {
-    href = href,
+  local parsed = {
     protocol = protocol,
     host = host,
     hostname = hostname,
@@ -96,7 +123,74 @@ local function parse(url, parseQueryString)
     auth = auth,
     hash = hash
   }
+  parsed.href = URL.format(parsed)
 
+  return parsed
 end
 
-return { parse = parse }
+local function format(parsed)
+  local auth = parsed.auth or ""
+  if auth ~= "" then
+    auth = encodeAuth(auth)
+    auth = auth .. '@'
+  end
+
+  local protocol = parsed.protocol or ""
+  local pathname = parsed.pathname or ""
+  local hash = parsed.hash or ""
+  local host = false
+  local query = ""
+  local port = parsed.port
+
+  if parsed.host and parsed.host ~= "" then
+    host = auth .. parsed.host
+  elseif parsed.hostname and parsed.hostname ~= "" then
+    host = auth .. parsed.hostname
+  end
+  -- extract port from host if possible
+  -- note: url.parse does not include the port in the host key, so
+  -- extracting the port here is just for convenience
+  if host then
+    host = string.gsub(host, "(:%d+)$", function(hostPort)
+      if not port then
+        port = string.sub(hostPort, 2)
+      end
+      return ""
+    end)
+  end
+  if host and port then
+    host = host .. ':' .. port
+  end
+
+  if parsed.query and type(parsed.query) == "table" then
+    query = querystring.stringify(parsed.query)
+  end
+
+  local search = parsed.search or (query ~= "" and ('?' .. query)) or ""
+
+  protocol = conditionallySuffix(protocol, ':')
+
+  -- urlencode # and ? characters only
+  pathname = string.gsub(pathname, '([?#])', function(c)
+    return string.format('%%%02X', byte(c))
+  end)
+
+  -- add slashes
+  if host then
+    host = '//' .. host
+    pathname = conditionallyPrefix(pathname, '/')
+  else
+    host = ""
+  end
+
+  search = string.gsub(search, '#', '%23')
+  hash = conditionallyPrefix(hash, '#')
+  search = conditionallyPrefix(search, '?')
+
+  return protocol .. host .. pathname .. search .. hash
+end
+
+URL.parse = parse
+URL.format = format
+
+return URL

--- a/tests/test-url.lua
+++ b/tests/test-url.lua
@@ -1,65 +1,31 @@
 local url = require("url")
 local deepEqual = require('deep-equal')
 
+local parseTests = {
+  ["http://localhost"] = {href = 'http://localhost', protocol = 'http', host = 'localhost', hostname = 'localhost', path = '/', pathname = '/'},
+  ["http://localhost/test"] = {href = 'http://localhost/test', protocol = 'http', host = 'localhost', hostname = 'localhost', path = '/test', pathname = '/test'},
+  ["http://localhost.local"] = {href = 'http://localhost.local', protocol = 'http', host = 'localhost.local', hostname = 'localhost.local', path = '/', pathname = '/'},
+  ["http://localhost:9000"] = {href = 'http://localhost:9000', protocol = 'http', host = 'localhost', hostname = 'localhost', path = '/', pathname = '/', port = '9000'},
+  ["https://creationix.com/foo/bar?this=sdr"] = {href = 'https://creationix.com/foo/bar?this=sdr', protocol = 'https', host = 'creationix.com', hostname = 'creationix.com', path = '/foo/bar?this=sdr', pathname = '/foo/bar', search = '?this=sdr', query = 'this=sdr'},
+  ["https://GabrielNicolasAvellaneda:s3cr3t@github.com:443/GabrielNicolasAvellaneda/luvit"] = {href = 'https://GabrielNicolasAvellaneda:s3cr3t@github.com:443/GabrielNicolasAvellaneda/luvit', protocol = 'https', auth = 'GabrielNicolasAvellaneda:s3cr3t', host = 'github.com', hostname = 'github.com', port = '443', path = '/GabrielNicolasAvellaneda/luvit', pathname = '/GabrielNicolasAvellaneda/luvit'},
+  ["creationix.com/"] = {href = 'creationix.com/', path = 'creationix.com/', pathname = 'creationix.com/'},
+  ["https://www.google.com.br/test#q=luvit"] = {href = 'https://www.google.com.br/test#q=luvit', protocol = 'https', host = 'www.google.com.br', hostname = 'www.google.com.br', path = '/test', pathname = '/test', hash = '#q=luvit'},
+}
+local parseTestsWithQueryString = {
+  ["/somepath?test=bar&ponies=foo"] = { pathname = '/somepath', query = {test = 'bar', ponies = 'foo'},href='/somepath?test=bar&ponies=foo',path='/somepath?test=bar&ponies=foo',search='?test=bar&ponies=foo'},
+}
+
 require('tap')(function(test)
-
-  test('should parse url http://localhost', function(expected)
-  local parsed = url.parse('http://localhost')
-  local expected = {href = 'http://localhost', protocol = 'http', host = 'localhost', hostname = 'localhost', path = '/', pathname = '/'}
-  assert(deepEqual(expected, parsed))
-  end)
-
-  test('should parse url http://localhost/test', function (expected)
-  local parsed = url.parse('http://localhost/test')
-  local expected = {href = 'http://localhost/test', protocol = 'http', host = 'localhost', hostname = 'localhost', path = '/test', pathname = '/test'}
-  assert(deepEqual(expected, parsed))
-  end)
-
-  test('should parse url http://localhost.local', function (expected)
-      local parsed = url.parse('http://localhost.local')
-      local expected = {href = 'http://localhost.local', protocol = 'http', host = 'localhost.local', hostname = 'localhost.local', path = '/', pathname = '/'}
+  for testUrl, expected in pairs(parseTests) do
+    test('should parse url '..testUrl, function ()
+      local parsed = url.parse(testUrl)
       assert(deepEqual(expected, parsed))
-  end)
-
-  test('should parse url http://localhost:9000', function (expected)
-  local parsed = url.parse('http://localhost:9000')
-  local expected = {href = 'http://localhost:9000', protocol = 'http', host = 'localhost', hostname = 'localhost', path = '/', pathname = '/', port = '9000'}
-  assert(deepEqual(expected, parsed))
-  end)
-
-  test('should parse url http://www.creationix.com/foo/bar?this=sdr', function (expected)
-  local parsed = url.parse('https://creationix.com/foo/bar?this=sdr')
-  local expected = {href = 'https://creationix.com/foo/bar?this=sdr', protocol = 'https', host = 'creationix.com', hostname = 'creationix.com', path = '/foo/bar?this=sdr', pathname = '/foo/bar', search = '?this=sdr', query = 'this=sdr'}
-  assert(deepEqual(expected, parsed))
-  end)
-
-  test('should parse url https://GabrielNicolasAvellaneda:s3cr3t@github.com:443/GabrielNicolasAvellaneda/luvit', function (expected)
-  local parsed = url.parse('https://GabrielNicolasAvellaneda:s3cr3t@github.com:443/GabrielNicolasAvellaneda/luvit')
-  local expected = {href = 'https://GabrielNicolasAvellaneda:s3cr3t@github.com:443/GabrielNicolasAvellaneda/luvit', protocol = 'https', auth = 'GabrielNicolasAvellaneda:s3cr3t', host = 'github.com', hostname = 'github.com', port = '443', path = '/GabrielNicolasAvellaneda/luvit', pathname = '/GabrielNicolasAvellaneda/luvit'}
-  assert(deepEqual(expected, parsed))
-  end)
-
-  test('should parse url creationix.com/', function (expected)
-  local parsed = url.parse('creationix.com/')
-  local expected = {href = 'creationix.com/', path = 'creationix.com/', pathname = 'creationix.com/'}
-  assert(deepEqual(expected, parsed))
-  end)
-
-  test('should parse url https://www.google.com.br/test#q=luvit', function (expected)
-  local parsed = url.parse('https://www.google.com.br/test#q=luvit')
-  local expected = {href = 'https://www.google.com.br/test#q=luvit', protocol = 'https', host = 'www.google.com.br', hostname = 'www.google.com.br', path = '/test', pathname = '/test', hash = '#q=luvit'}
-  assert(deepEqual(expected, parsed))
-  end)
-
-  test('should parse url /somepath?test=bar&ponies=foo', function (expected)
-  local parsed = url.parse('/somepath?test=bar&ponies=foo')
-  local expected = { pathname = '/somepath', query = 'test=bar&ponies=foo',href='/somepath?test=bar&ponies=foo',path='/somepath?test=bar&ponies=foo',search='?test=bar&ponies=foo'}
-  assert(deepEqual(expected, parsed))
-  end)
-
-  test('should parse url /somepath?test=bar&ponies=foo with querystring', function (expected)
-  local parsed = url.parse('/somepath?test=bar&ponies=foo',true)
-  local expected = { pathname = '/somepath', query = {test = 'bar', ponies = 'foo'},href='/somepath?test=bar&ponies=foo',path='/somepath?test=bar&ponies=foo',search='?test=bar&ponies=foo'}
-  assert(deepEqual(expected, parsed))
-  end)
+    end)
+  end
+  for testUrl, expected in pairs(parseTestsWithQueryString) do
+    test('should parse url '..testUrl..' with querystring', function ()
+      local parsed = url.parse(testUrl, true)
+      assert(deepEqual(expected, parsed))
+    end)
+  end
 end)

--- a/tests/test-url.lua
+++ b/tests/test-url.lua
@@ -5,9 +5,9 @@ local parseTests = {
   ["http://localhost"] = {href = 'http://localhost/', protocol = 'http', host = 'localhost', hostname = 'localhost', path = '/', pathname = '/'},
   ["http://localhost/test"] = {href = 'http://localhost/test', protocol = 'http', host = 'localhost', hostname = 'localhost', path = '/test', pathname = '/test'},
   ["http://localhost.local"] = {href = 'http://localhost.local/', protocol = 'http', host = 'localhost.local', hostname = 'localhost.local', path = '/', pathname = '/'},
-  ["http://localhost:9000"] = {href = 'http://localhost:9000/', protocol = 'http', host = 'localhost', hostname = 'localhost', path = '/', pathname = '/', port = '9000'},
+  ["http://localhost:9000"] = {href = 'http://localhost:9000/', protocol = 'http', host = 'localhost:9000', hostname = 'localhost', path = '/', pathname = '/', port = '9000'},
   ["https://creationix.com/foo/bar?this=sdr"] = {href = 'https://creationix.com/foo/bar?this=sdr', protocol = 'https', host = 'creationix.com', hostname = 'creationix.com', path = '/foo/bar?this=sdr', pathname = '/foo/bar', search = '?this=sdr', query = 'this=sdr'},
-  ["https://GabrielNicolasAvellaneda:s3cr3t@github.com:443/GabrielNicolasAvellaneda/luvit"] = {href = 'https://GabrielNicolasAvellaneda:s3cr3t@github.com:443/GabrielNicolasAvellaneda/luvit', protocol = 'https', auth = 'GabrielNicolasAvellaneda:s3cr3t', host = 'github.com', hostname = 'github.com', port = '443', path = '/GabrielNicolasAvellaneda/luvit', pathname = '/GabrielNicolasAvellaneda/luvit'},
+  ["https://GabrielNicolasAvellaneda:s3cr3t@github.com:443/GabrielNicolasAvellaneda/luvit"] = {href = 'https://GabrielNicolasAvellaneda:s3cr3t@github.com:443/GabrielNicolasAvellaneda/luvit', protocol = 'https', auth = 'GabrielNicolasAvellaneda:s3cr3t', host = 'github.com:443', hostname = 'github.com', port = '443', path = '/GabrielNicolasAvellaneda/luvit', pathname = '/GabrielNicolasAvellaneda/luvit'},
   ["creationix.com/"] = {href = 'creationix.com/', path = 'creationix.com/', pathname = 'creationix.com/'},
   ["https://www.google.com.br/test#q=luvit"] = {href = 'https://www.google.com.br/test#q=luvit', protocol = 'https', host = 'www.google.com.br', hostname = 'www.google.com.br', path = '/test', pathname = '/test', hash = '#q=luvit'},
 }

--- a/tests/test-url.lua
+++ b/tests/test-url.lua
@@ -2,10 +2,10 @@ local url = require("url")
 local deepEqual = require('deep-equal')
 
 local parseTests = {
-  ["http://localhost"] = {href = 'http://localhost', protocol = 'http', host = 'localhost', hostname = 'localhost', path = '/', pathname = '/'},
+  ["http://localhost"] = {href = 'http://localhost/', protocol = 'http', host = 'localhost', hostname = 'localhost', path = '/', pathname = '/'},
   ["http://localhost/test"] = {href = 'http://localhost/test', protocol = 'http', host = 'localhost', hostname = 'localhost', path = '/test', pathname = '/test'},
-  ["http://localhost.local"] = {href = 'http://localhost.local', protocol = 'http', host = 'localhost.local', hostname = 'localhost.local', path = '/', pathname = '/'},
-  ["http://localhost:9000"] = {href = 'http://localhost:9000', protocol = 'http', host = 'localhost', hostname = 'localhost', path = '/', pathname = '/', port = '9000'},
+  ["http://localhost.local"] = {href = 'http://localhost.local/', protocol = 'http', host = 'localhost.local', hostname = 'localhost.local', path = '/', pathname = '/'},
+  ["http://localhost:9000"] = {href = 'http://localhost:9000/', protocol = 'http', host = 'localhost', hostname = 'localhost', path = '/', pathname = '/', port = '9000'},
   ["https://creationix.com/foo/bar?this=sdr"] = {href = 'https://creationix.com/foo/bar?this=sdr', protocol = 'https', host = 'creationix.com', hostname = 'creationix.com', path = '/foo/bar?this=sdr', pathname = '/foo/bar', search = '?this=sdr', query = 'this=sdr'},
   ["https://GabrielNicolasAvellaneda:s3cr3t@github.com:443/GabrielNicolasAvellaneda/luvit"] = {href = 'https://GabrielNicolasAvellaneda:s3cr3t@github.com:443/GabrielNicolasAvellaneda/luvit', protocol = 'https', auth = 'GabrielNicolasAvellaneda:s3cr3t', host = 'github.com', hostname = 'github.com', port = '443', path = '/GabrielNicolasAvellaneda/luvit', pathname = '/GabrielNicolasAvellaneda/luvit'},
   ["creationix.com/"] = {href = 'creationix.com/', path = 'creationix.com/', pathname = 'creationix.com/'},
@@ -20,12 +20,28 @@ require('tap')(function(test)
     test('should parse url '..testUrl, function ()
       local parsed = url.parse(testUrl)
       assert(deepEqual(expected, parsed))
+
+      local formatted = url.format(expected)
+      assert(formatted == expected.href, formatted .. ' should equal '.. expected.href)
     end)
   end
+
   for testUrl, expected in pairs(parseTestsWithQueryString) do
     test('should parse url '..testUrl..' with querystring', function ()
       local parsed = url.parse(testUrl, true)
       assert(deepEqual(expected, parsed))
+
+      local formatted = url.format(expected)
+      assert(formatted == expected.href, formatted .. ' should equal '.. expected.href)
     end)
   end
+
+  test('format should extract port from host', function()
+    local parsed = url.parse("http://localhost")
+    parsed.host = parsed.host .. ":9000"
+    assert(not parsed.port)
+
+    local formatted = url.format(parsed)
+    assert(formatted == "http://localhost:9000/")
+  end)
 end)


### PR DESCRIPTION
Some notes:

- ~~I kept the Luvit url.parse functionality (host = hostname)~~. Now changes `url.parse` to return `host` with the port included. Closes #891
- This is a pretty shallow port of Node's url.format, with just the basic functionality included (Luvit's url.parse is similarly shallow compared to Node).
- Running url.parse's href return through url.format matches what Node does