### PR TITLE
run.lua: Add support for running a specific test

### DIFF
--- a/tests/run.lua
+++ b/tests/run.lua
@@ -31,7 +31,7 @@ while true do
     name = name.name
   end
   local match = string.match(name, "^test%-(.*).lua$")
-  if match then
+  if match and (not args[2] or args[2] == match) then
     local path = "./test-" .. match
     tap(match)
     require(path)


### PR DESCRIPTION
 - Can run only the specified test file by passing the relevant part of the filename as args[2]. Example from within a checked out Luvit repo: `luvi . -- tests/run.lua http` will run the tests in test-http.lua only
 - Useful when working on a specific lib or a specific test script

---

This is just something that has been really useful for me, and I thought I'd submit it as a PR just in case it's wanted. Let me know if you think the implementation could be improved.