### PR TITLE
repl: Fix error() calls with a non-string message breaking the repl

### DIFF
--- a/deps/repl.lua
+++ b/deps/repl.lua
@@ -97,9 +97,12 @@ return function (stdin, stdout, greeting)
         if results.n > 0 then
           printResults(results)
         end
-      else
+      elseif type(results[1]) == 'string' then
         -- error
         stdout:write(results[1] .. '\n')
+      else
+        -- error calls with non-string message objects will pass through debug.traceback without a stacktrace added
+        stdout:write('error with unexpected error message type (' .. type(results[1]) .. '), no stacktrace available\n')
       end
     else
 


### PR DESCRIPTION
Fixes #898

`error()` calls with non-string messages will now output the following:

```
Welcome to the Luvit repl!
> error(function() end)
error with unexpected error message type (function), no stacktrace available
> error()
error with unexpected error message type (nil), no stacktrace available
```

Let me know if you think there's a better way to handle this, or if the message could be made clearer.