### PR TITLE
Changed random seed from os.clock to os.time

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -25,7 +25,7 @@ return function (main, ...)
   do
     local math = require('math')
     local os = require('os')
-    math.randomseed(os.clock())
+    math.randomseed(os.time())
   end
 
   -- Load Resolver


### PR DESCRIPTION
Luvit currently uses `os.clock()`, a measure of processor time, to seed the RNG, but this value is often not unique. `os.time()` guarantees a unique seed as long as at least one second lapses between executions, and is the [recommended method](https://www.lua.org/pil/18.html).