### PR TITLE
Add os.time() to random seed

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -25,7 +25,7 @@ return function (main, ...)
   do
     local math = require('math')
     local os = require('os')
-    math.randomseed(os.time())
+    math.randomseed(os.time()*os.clock())
   end
 
   -- Load Resolver


### PR DESCRIPTION
`os.time` by itself is not very accurate, yet `os.clock()` is not very unique. The solution? Multiply them together! This will almost always generate guaranteed random numbers.