### PR TITLE
Fix childprogress.exec return

### DIFF
--- a/deps/childprocess.lua
+++ b/deps/childprocess.lua
@@ -272,6 +272,8 @@ local function _exec(file, args, options, callback)
   end)
 
   child:once('close', onClose)
+  
+  return child
 end
 
 local function execFile(file, args, options, callback)


### PR DESCRIPTION
Fixed child progress return.

```lua
local childProcess = require('childprocess')
local child = childProcess.exec(command, options, callback)
-- child shouldn't be nil;
```