### PR TITLE
allow loading from 'modules' sub-dir as legacy version

### DIFF
--- a/deps/boundary.lua
+++ b/deps/boundary.lua
@@ -1,0 +1,50 @@
+-- Copyright 2015 Boundary
+-- @brief convenience variables and functions for Lua scripts
+-- @file boundary.lua
+--
+--[[lit-meta
+  name = "luvit/boundary"
+  version = "2.0.0"
+  license = "Apache 2"
+  homepage = "https://github.com/luvit/luvit/blob/master/deps/core.lua"
+  description = "Core object model for luvit using simple prototypes and inheritance."
+  tags = {"luvit", "objects", "inheritance"}
+]]
+local fs = require('fs')
+local json = require('json')
+local path = require('path')
+
+local boundary = {argv = nil, param = nil, plugin = {}}
+local plugin_basedir = "."
+
+-- create table of cmdline args (boundary.argv)
+boundary.argv = process.argv or nil
+if boundary.argv ~= nil then
+  -- if '--plguin-basedir' is present as the first arg, use its value as the path
+  -- to the param.json file and remove it from the arg table
+  if boundary.argv[1] == '--plugin-basedir' then
+    plugin_basedir = boundary.argv[2]
+    table.remove(boundary.argv, 1)
+    table.remove(boundary.argv, 1)
+  end
+end
+
+-- import param.json data into a Lua table (boundary.param)
+local json_blob
+if (pcall(function () json_blob = fs.readFileSync(plugin_basedir.."/param.json") end)) then
+  pcall(function () boundary.param = json.parse(json_blob) end)
+end
+if (pcall(function () json_blob = fs.readFileSync("./plugin.json") end)) then
+  pcall(function () boundary.plugin = json.parse(json_blob) end)
+end
+-- set defaults if version and name are not present
+boundary.plugin.version = boundary.plugin.version or "0.0"
+if boundary.plugin.name == nil then
+  local cwd = process.cwd()
+  boundary.plugin.name = path.basename(cwd)
+  if boundary.plugin.name == "plugin" then
+    boundary.plugin.name = path.basename(path.dirname(cwd))
+  end
+end
+
+return boundary

--- a/deps/require.lua
+++ b/deps/require.lua
@@ -183,6 +183,10 @@ local function moduleRequire(base, name)
         mod, path, key = fixedRequire(pathJoin(base, "deps", name))
         if mod then return mod, path, key end
       end
+      if isDir(pathJoin(base, "modules")) then
+        mod, path, key = fixedRequire(pathJoin(base, "modules", name))
+        if mod then return mod, path, key end
+      end
     end
 
     -- Stop at filesystem or prefix root (58 is ":")

--- a/init.lua
+++ b/init.lua
@@ -15,9 +15,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 --]]
-local uv = require('uv')
 
 return function (main, ...)
+  -- truesight backward changes
+  local uv = require('uv')
+  local timer = {}
+  timer.now = uv.now
+  uv.Timer = timer
+
   -- Inject the global process table
   _G.process = require('process').globalProcess()
 

--- a/package.lua
+++ b/package.lua
@@ -50,6 +50,7 @@ return {
     "luvit/tls@2.0.0",
     "luvit/utils@2.0.0",
     "luvit/url@2.0.0",
+    "luvit/boundary@2.0.0",
   },
   files = {
     "*.lua",


### PR DESCRIPTION
To be backward compatible with legacy version. 
We are using legacy version now, our libraries are located under 'modules' sub-dir.  Now we want to take advantage of the latest luvit. Can we add this fix so that our existing code will still work?

thanks
Kevin Chen 