### PR TITLE
(#924) Support UTF-8 and fix readline

### DIFF
--- a/deps/readline.lua
+++ b/deps/readline.lua
@@ -18,6 +18,9 @@ limitations under the License.
 --[[lit-meta
   name = "luvit/readline"
   version = "2.1.0"
+  dependencies = {
+    "luvit/ustring@2.0.0",
+  }
   homepage = "https://github.com/luvit/luvit/blob/master/deps/readline.lua"
   description = "A readline interface for terminals in pure lua."
   tags = {"readline", "tty"}

--- a/deps/readline.lua
+++ b/deps/readline.lua
@@ -30,6 +30,7 @@ limitations under the License.
 local ustring = require "ustring"
 local emptyline = ustring.new()
 local sub = ustring.sub
+local chlen = ustring.chlen
 local gmatch = ustring.gmatch
 local remove = table.remove
 local insert = table.insert
@@ -397,7 +398,7 @@ local keyHandlers =
     self:getHistory(10)
   end},
   -- Printable characters
-  {{function(key, char) return char > 31 and key or nil end}, function(self, consumedKeys)
+  {{function(key, char) return char > 31 and key:sub(1,chlen(key:byte())) or nil end}, function(self, consumedKeys)
     self:insert(consumedKeys)
   end},
 }

--- a/deps/readline.lua
+++ b/deps/readline.lua
@@ -32,6 +32,7 @@ local emptyline = ustring.new()
 local sub = ustring.sub
 local chlen = ustring.chlen
 local gmatch = ustring.gmatch
+local find = ustring.find
 local remove = table.remove
 local insert = table.insert
 local concat = table.concat
@@ -219,7 +220,7 @@ local function findLeft(line, position, wordPattern)
   local s
   repeat
     local start = sub(line, 1, position - 1)
-    s = string.find(start, pattern)
+    s = find(start, pattern)
     if not s then
       position = position - 1
     end
@@ -240,7 +241,7 @@ function Editor:jumpLeft()
   self:refreshLine()
 end
 function Editor:jumpRight()
-  local _, e = string.find(self.line, self.wordPattern, self.position)
+  local _, e = find(self.line, self.wordPattern, self.position)
   self.position = e and e + 1 or #self.line + 1
   self:refreshLine()
 end

--- a/deps/readline.lua
+++ b/deps/readline.lua
@@ -34,6 +34,7 @@ local gmatch = ustring.gmatch
 local remove = table.remove
 local insert = table.insert
 local concat = table.concat
+local tostring = tostring
 
 local History = {}
 function History:add(line)
@@ -124,7 +125,7 @@ function Editor:insert(character)
     self.position = position + #character
     self:refreshLine()
   end
-  self.history:updateLastLine(self.line)
+  self.history:updateLastLine(tostring(self.line))
 end
 function Editor:moveLeft()
   if self.position > 1 then
@@ -163,7 +164,7 @@ function Editor:backspace()
   if position > 1 and #line > 0 then
     self.line = sub(line, 1, position - 2) .. sub(line, position)
     self.position = position - 1
-    self.history:updateLastLine(self.line)
+    self.history:updateLastLine(tostring(self.line))
     self:refreshLine()
   end
 end
@@ -172,7 +173,7 @@ function Editor:delete()
   local position = self.position
   if position > 0 and #line > 0 then
     self.line = sub(line, 1, position - 1) .. sub(line, position + 1)
-    self.history:updateLastLine(self.line)
+    self.history:updateLastLine(tostring(self.line))
     self:refreshLine()
   end
 end
@@ -187,19 +188,19 @@ function Editor:swap()
     if position ~= #line then
       self.position = position + 1
     end
-    self.history:updateLastLine(self.line)
+    self.history:updateLastLine(tostring(self.line))
     self:refreshLine()
   end
 end
 function Editor:deleteLine()
   self.line = emptyline
   self.position = 1
-  self.history:updateLastLine(self.line)
+  self.history:updateLastLine(tostring(self.line))
   self:refreshLine()
 end
 function Editor:deleteEnd()
   self.line = sub(self.line, 1, self.position - 1)
-  self.history:updateLastLine(self.line)
+  self.history:updateLastLine(tostring(self.line))
   self:refreshLine()
 end
 function Editor:moveHome()
@@ -255,7 +256,7 @@ function Editor:complete()
   end
   local line = self.line
   local position = self.position
-  local res = self.completionCallback(sub(line, 1, position))
+  local res = self.completionCallback(tostring(sub(line, 1, position)))
   if not res then
     return self:beep()
   end
@@ -264,7 +265,7 @@ function Editor:complete()
     res = ustring.new(res)
     self.line = res .. sub(line, position + 1)
     self.position = #res + 1
-    self.history:updateLastLine(self.line)
+    self.history:updateLastLine(tostring(self.line))
   elseif typ == "table" then
     print()
     print(unpack(res))

--- a/deps/repl.lua
+++ b/deps/repl.lua
@@ -75,7 +75,7 @@ return function (stdin, stdout, greeting)
   local buffer = ''
 
   local function evaluateLine(line)
-    if line == "<3" or line == "♥" then
+    if line == "<3" or line == "♥" or line == "❤" then
       stdout:write("I " .. c("err") .. "♥" .. c() .. " you too!\n")
       return '>'
     end

--- a/deps/ustring.lua
+++ b/deps/ustring.lua
@@ -110,6 +110,7 @@ end
 
 function ustring.find(ustr,pattern,init,plain)
     local first,last = find(tostring(ustr),tostring(pattern),init,plain)
+    if first == nil then return nil end
     local ufirst = ustring.uindex(ustr,first)
     local ulast = ustring.uindex(ustr,last,first,ufirst)
     return ufirst,ulast
@@ -130,7 +131,7 @@ end
 function ustring.lower(ustr)
     local u = ustring.copy(ustr)
     for i = 1,#u do
-        u = lower(u)
+        u[i] = lower(u[i])
     end
     return u
 end
@@ -138,7 +139,7 @@ end
 function ustring.upper(ustr)
     local u = ustring.copy(ustr)
     for i = 1,#u do
-        u = upper(u)
+        u[i] = upper(u[i])
     end
     return u
 end
@@ -165,9 +166,6 @@ end
 _meta.__index = ustring
 
 function _meta.__eq(ustr1,ustr2)
-    if type(ustr2) == "string" then
-        return tostring(ustr1) == ustr2
-    end
     local len1 = #ustr1
     local len2 = #ustr2
     if len1 ~= len2 then return false end

--- a/deps/ustring.lua
+++ b/deps/ustring.lua
@@ -48,7 +48,7 @@ function ustring.new(str,allowInvaild)
         end
 
         local charLen = chlen(byte)
-        assert(charLen ~= 0 or allowInvaild,"Invaild UTF-8 sequence at "..tostring(i)..",byte:"..tostring(byte))
+        if charLen == 0 and not allowInvaild then error("Invaild UTF-8 sequence at "..tostring(i)..",byte:"..tostring(byte)) end
         ustr[index] = char
         if charLen == 1 then index = index + 1 end
         append = append + charLen - 1

--- a/deps/ustring.lua
+++ b/deps/ustring.lua
@@ -1,0 +1,188 @@
+local ustring = {}
+local tostring = tostring
+local _meta = {}
+
+local strsub = string.sub
+local strbyte = string.byte
+local band = bit.band
+local rshift = bit.rshift
+function ustring.new(str,allowInvaild)
+    local str = str and tostring(str) or ""
+    local ustr = {}
+    local index = 1;
+    local append = 0;
+    for i = 1,#str do
+        repeat
+        local char = strsub(str,i,i)
+        local byte = strbyte(char)
+        if append ~= 0 then
+            if not allowInvaild then
+                if rshift(byte,6) ~= 0x02 then
+                    error("Invaild UTF-8 sequence at "..i)
+                end
+            end
+            ustr[index] = ustr[index] .. char
+            append = append - 1
+            if append == 0 then
+                index = index + 1
+            end
+            break
+        end
+
+        if rshift(byte,7) == 0x00 then -- 1 byte (ansi)
+            ustr[index] = char
+            index = index + 1
+        elseif rshift(byte,5) == 0x06 then -- 2 bytes
+            ustr[index] = char
+            append = 1
+        elseif rshift(byte,4) == 0x0E then -- 3 bytes
+            ustr[index] = char
+            append = 2
+        elseif rshift(byte,3) == 0x1E then -- 4 bytes
+            ustr[index] = char
+            append = 3
+        else
+            -- RFC 3629 (2003.11) says UTF-8 don't have characters larger than 4 bytes.
+            -- They will not be processed although they may be appeared in some old systems.
+            if not allowInvaild then
+                error("Invaild UTF-8 sequence at "..i..",byte:"..byte)
+            end
+        end
+
+        until true
+    end
+    setmetatable(ustr,_meta)
+    return ustr
+end
+
+function ustring.copy(ustr)
+    local u = ustring.new()
+    for i = 1,#ustr do
+        u[i] = ustr[i]
+    end
+    return u
+end
+
+function ustring.uindex(ustr,rawindex,initrawindex,initindex)
+    -- get the index of the UTF-8 character from a raw string index
+    -- return `nil` when rawindex is invaild
+    -- the last 2 arguments is used for speed up
+    local index = (initindex or 1)
+    rawindex = rawindex - (initrawindex or 1) + 1
+    repeat
+        local byte = ustr[index]
+        if byte == nil then return nil end
+        local len = #byte
+        index = index + 1
+        rawindex = rawindex - len
+    until rawindex <= 0
+    return index - 1
+end
+
+local gsub = string.gsub
+local find = string.find
+local format = string.format
+local gmatch = string.gmatch
+local match = string.match
+local lower = string.lower
+local upper = string.upper
+ustring.len = rawlen
+
+function ustring.gsub(ustr,pattern,repl,n)
+    return ustring.new(gsub(tostring(ustr),tostring(pattern),tostring(repl),n))
+end
+
+function ustring.sub(ustr,i,j)
+    local u = ustring.new()
+    j = j or -1
+    local len = #ustr
+    if i < 0 then i = len + i + 1 end
+    if j < 0 then j = len + j + 1 end
+    for ii = i,math.min(j,len) do
+        u[#u + 1] = ustr[ii]
+    end
+    return u
+end
+
+function ustring.find(ustr,pattern,init,plain)
+    local first,last = find(tostring(ustr),tostring(pattern),init,plain)
+    local ufirst = ustring.uindex(ustr,first)
+    local ulast = ustring.uindex(ustr,last,first,ufirst)
+    return ufirst,ulast
+end
+
+function ustring.format(formatstring,...)
+    return ustring.new(format(tostring(formatstring),...))
+end
+
+function ustring.gmatch(ustr,pattern)
+    return gmatch(tostring(ustr),pattern)
+end
+
+function ustring.match(ustr,pattern,init)
+    return match(tostring(ustr),tostring(pattern),init)
+end
+
+function ustring.lower(ustr)
+    local u = ustring.copy(ustr)
+    for i = 1,#u do
+        u = lower(u)
+    end
+    return u
+end
+
+function ustring.upper()
+    local u = ustring.copy(ustr)
+    for i = 1,#u do
+        u = upper(u)
+    end
+    return u
+end
+
+function ustring.rep(ustr,n)
+    local u = ustring.new()
+    for i = 1,n do
+        for ii = 1,#ustr do
+           u[#u + 1] = ustr[ii]
+        end
+    end
+    return u
+end
+
+function ustring.reverse(ustr)
+    local u = ustring.copy(ustr)
+    local len = #ustr;
+    for i = 1,len do
+        u[i] = ustr[len - i + 1]
+    end
+    return u
+end
+
+_meta.__index = ustring
+
+function _meta.__eq(ustr1,ustr2)
+    local len1 = #ustr1
+    local len2 = #ustr2
+    if len1 ~= len2 then return false end
+
+    for i = 1,len1 do
+        if ustr1[i] ~= ustr2[i] then return false end
+    end
+    return true
+end
+
+function _meta.__tostring(self)
+    return tostring(table.concat(self))
+end
+
+function _meta.__concat(ustr1,ustr2)
+    local u = ustring.copy(ustr1)
+    for i = 1,#ustr2 do
+        u[#u + 1] = ustr2[i]
+    end
+    return u
+end
+
+_meta.__len = ustring.len
+
+return ustring

--- a/deps/ustring.lua
+++ b/deps/ustring.lua
@@ -1,3 +1,29 @@
+--[[
+
+Copyright 2014-2015 The Luvit Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+--]]
+--[[lit-meta
+  name = "luvit/ustring"
+  version = "2.0.0"
+  homepage = "https://github.com/luvit/luvit/blob/master/deps/ustring.lua"
+  description = "A light-weight UTF-8 module in pure lua(jit)."
+  tags = {"ustring", "utf8", "utf-8", "unicode"}
+  license = "Apache 2"
+]]
+
 local ustring = {}
 local tostring = tostring
 local _meta = {}

--- a/deps/ustring.lua
+++ b/deps/ustring.lua
@@ -131,7 +131,7 @@ function ustring.lower(ustr)
     return u
 end
 
-function ustring.upper()
+function ustring.upper(ustr)
     local u = ustring.copy(ustr)
     for i = 1,#u do
         u = upper(u)
@@ -161,6 +161,9 @@ end
 _meta.__index = ustring
 
 function _meta.__eq(ustr1,ustr2)
+    if type(ustr2) == "string" then
+        return tostring(ustr1) == ustr2
+    end
     local len1 = #ustr1
     local len2 = #ustr2
     if len1 ~= len2 then return false end

--- a/package.lua
+++ b/package.lua
@@ -50,6 +50,7 @@ return {
     "luvit/tls@2.0.0",
     "luvit/utils@2.0.0",
     "luvit/url@2.0.0",
+    "luvit/ustring@2.0.0"
   },
   files = {
     "*.lua",

--- a/tests/test-readline.lua
+++ b/tests/test-readline.lua
@@ -43,27 +43,27 @@ require('tap')(function(test)
 
     -- single key
     editor:onKey('a')
-    assert(editor.line == "a")
+    assert(tostring(editor.line) == "a")
     assert(editor.position == 2)
 
     -- left arrow
     editor:onKey('\027[D')
-    assert(editor.line == "a")
+    assert(tostring(editor.line) == "a")
     assert(editor.position == 1)
 
     -- multiple keys
     editor:onKey('abc')
-    assert(editor.line == "abca")
+    assert(tostring(editor.line) == "abca")
     assert(editor.position == 4)
 
     -- multiple control sequences (left arrows)
     editor:onKey('\027[D\027[D\027[D')
-    assert(editor.line == "abca")
+    assert(tostring(editor.line) == "abca")
     assert(editor.position == 1)
 
     -- mixture of characters and control sequences
     editor:onKey('a\027[Db\027[Dc\027[Dd')
-    assert(editor.line == "dcbaabca")
+    assert(tostring(editor.line) == "dcbaabca")
     assert(editor.position == 2)
   end)
 end)

--- a/tests/test-ustring.lua
+++ b/tests/test-ustring.lua
@@ -1,0 +1,83 @@
+--[[
+
+Copyright 2015 The Luvit Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+--]]
+
+--[[!!!
+    NOTICE:
+    This file contains some Emoji character.
+    Your editor may display them incorrectly, but please DO NOT delete them :)
+]]
+
+local ustring = require('ustring')
+
+local function compareTable(t1,t2)
+    if #t1 ~= #t2 then return false end
+    for i = 1,#t1 do
+        if rawget(t1,i) ~= rawget(t2,i) then return false end
+    end
+    return true
+end
+
+require('tap')(function(test)
+  test('ustring', function(expect)
+    
+    -- construct & tostring
+    local r = "abc123\11\27\0中文-日本語-한국❤😘😄💎💛"
+    local u = ustring.new(r)
+    local e = {
+    'a','b','c','1','2','3','\11','\27','\0',
+    '中','文','-','日','本','語','-','한','국', -- Chinese - Japanese - Korean
+    '❤','😘','😄','💎','💛'-- Emoji
+    }
+    assert(compareTable(u,e))
+    assert(tostring(u) == r) -- __tostring
+    local u2 = u:copy()
+    assert(compareTable(u2,u))
+    assert(compareTable(u2,e))
+    assert(u2 == u) -- __eq
+    
+    -- uindex
+    assert(u:uindex(13) == 11)
+    assert(u:uindex(43) == 21)
+    assert(u:uindex(13,10,10) == 11)
+    assert(u:uindex(43,39,20) == 21)
+    
+    -- other
+    local u = ustring.new "xx中x中😄" .. ustring.new "文💛"
+    assert(tostring(u) == "xx中x中😄文💛")
+
+    assert(tostring(u:sub(3,-3)) == "中x中😄")
+    assert(tostring(u:sub(-2,7)) == '文')
+
+    local first,last = u:find("中x中")
+    assert(first == 3)
+    assert(last == 5)
+    local first,last = u:find("中",4)
+    assert(first == 5)
+    assert(last == 5)
+
+    assert(tostring(ustring.format(ustring.new "格式%s测试：,%i","文本",4685)) == "格式文本测试：,4685")
+
+    assert(tostring(ustring.new("abcde参杂fghijk"):upper()) == "ABCDE参杂FGHIJK")
+    assert(tostring(ustring.new("ABCDEFGHIJK"):lower()) == "abcdefghijk")
+
+    assert(tostring(ustring.rep(ustring.new"💙💛💙💜",4)) == "💙💛💙💜💙💛💙💜💙💛💙💜💙💛💙💜")
+
+    assert(tostring(ustring.new("翻转测试reverse test"):reverse()) == "tset esrever试测转翻")
+
+  end)
+end)


### PR DESCRIPTION
This fixed #924.
I've write a new module `ustring` to process UTF-8 strings.It has similar APIs to standard `string` module.
And with this new module,the issue was fixed.
**PS:I don't know how `lit` package management system works,but my changes may cause `readline` become depending on `ustring`.**