### PR TITLE
fix stream closing

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+# Changes in 2.12.1
+
+ - childprocess: Fix spawn to cleanup correctly (Ryan Phillips)
+
 # Changes in 2.12.0
 
  - childprocess: Fix `childprogress.exec` return. (Cyril Hou)

--- a/deps/childprocess.lua
+++ b/deps/childprocess.lua
@@ -64,21 +64,9 @@ function Process:close(err)
 end
 
 function Process:destroy(err)
-  self:_cleanup(err)
   if err then
     timer.setImmediate(function() self:emit('error', err) end)
   end
-end
-
-function Process:_cleanup(err)
-  timer.setImmediate(function()
-    if self.stdout then
-      self.stdout:_end(err) -- flush
-      self.stdout:destroy(err) -- flush
-    end
-    if self.stderr then self.stderr:destroy(err) end
-    if self.stdin then self.stdin:destroy(err) end
-  end)
 end
 
 local function spawn(command, args, options)
@@ -155,6 +143,10 @@ local function spawn(command, args, options)
   em = Process:new(stdin, stdout, stderr)
   em:setHandle(handle)
   em:setPid(pid)
+
+  if stdout then stdout:resume() end
+  if stderr then stderr:resume() end
+  if stdin then stdin:resume() end
 
   if not em.handle then
     timer.setImmediate(function()

--- a/deps/childprocess.lua
+++ b/deps/childprocess.lua
@@ -144,18 +144,21 @@ local function spawn(command, args, options)
   em:setHandle(handle)
   em:setPid(pid)
 
-  if stdout then stdout:resume() end
-  if stderr then stderr:resume() end
-  if stdin then stdin:resume() end
-
   if not em.handle then
     timer.setImmediate(function()
       em.exitCode = -127
       em:emit('exit', em.exitCode)
-      em:destroy(Error:new(pid))
+      em:emit('error', Error:new(pid))
+      if em.stdout then em.stdout:emit('error', Error:new(pid)) end
+      if em.stderr then em.stderr:emit('error', Error:new(pid)) end
+      if em.stdin then em.stdin:emit('error', Error:new(pid)) end
       maybeClose()
     end)
   end
+
+  if stdout then stdout:resume() end
+  if stderr then stderr:resume() end
+  if stdin then stdin:resume() end
 
   return em
 end

--- a/deps/childprocess.lua
+++ b/deps/childprocess.lua
@@ -17,7 +17,7 @@ limitations under the License.
 --]]
 --[[lit-meta
   name = "luvit/childprocess"
-  version = "2.1.0"
+  version = "2.1.1"
   dependencies = {
     "luvit/core@2.0.0",
     "luvit/utils@2.0.0",

--- a/package.lua
+++ b/package.lua
@@ -1,6 +1,6 @@
 return {
   name = "luvit/luvit",
-  version = "2.12.0",
+  version = "2.12.1",
   luvi = {
     version = "2.7.6",
     flavor = "regular",
@@ -21,7 +21,7 @@ return {
   },
   dependencies = {
     "luvit/buffer@2.0.0",
-    "luvit/childprocess@2.0.0",
+    "luvit/childprocess@2.1.1",
     "luvit/codec@2.0.0",
     "luvit/core@2.0.0",
     "luvit/dgram@2.0.0",


### PR DESCRIPTION
The exit callback from the spawn gets triggered before the data from the pipes is read and flushed. That exit callback calls `shutdown` on those pending pipes before they are done.

This change causes the pipe streams to automatically shutdown when they get closed by the stream. The issue only manifests itself on a busy server, and when multiple spawns are called on the same tick, which is why we have not seen it before.