### PR TITLE
dns: Fix IPv6 address matching

### DIFF
--- a/deps/dns.lua
+++ b/deps/dns.lua
@@ -608,7 +608,7 @@ local function _query(servers, name, dnsclass, qtype, callback)
 
   -- Try to resolve IPs directly, without contacting DNS servers
   if (qtype == TYPE_A and match(name, "^%d+%.%d+%.%d+%.%d+$")) -- numeric IPv4
-     or (qtype == TYPE_AAAA and match(name, "^[:%x]+$")) -- hexadecimal IPv6
+     or (qtype == TYPE_AAAA and match(name, "^%x*:[.:%x]+$")) -- IPv6
   then
     -- Answer query 'locally', by passing suitable arguments to the callback
     -- function. This reports a single address result, with no (`nil`) name,


### PR DESCRIPTION
The previous pattern for IPv6 address detection was overly simply.
This new filter requires at least one ':' to be present within the
address, and it also allows for dots in the notation of IPv4-mapped
IPv6 (e.g. ::ffff:192.0.2.128).

See https://en.wikipedia.org/wiki/IPv6_address#Representation