### PR TITLE
Fix bundle requires on Windows

### DIFF
--- a/deps/require.lua
+++ b/deps/require.lua
@@ -179,12 +179,12 @@ local function moduleRequire(base, name)
       end
     end
 
-    if base == "/" then
-      -- If we reach filesystem root, look in root on bundle
-      base = "bundle:"
-    elseif base:byte(-1) == 58 then
+    if base == "bundle:" then
       -- If we reach root of bundle, it doesn't exist
       break
+    elseif base == "/" or base:byte(-1) == 58 then
+      -- If we reach filesystem root, look in bundle
+      base = "bundle:"
     else
       -- Otherwise, keep going higher
       base = pathJoin(base, "..")


### PR DESCRIPTION
Bundle requires were only being loaded when reaching / as root, but something like C: is the root on Windows, so the bundle was never being looked in (because it was assuming something like C: was the bundle root rather than the filesystem root).

(see comments in https://github.com/luvit/luvit/pull/973)