### PR TITLE
Support punctuation in http credentials

### DIFF
--- a/deps/url.lua
+++ b/deps/url.lua
@@ -70,7 +70,7 @@ local function parse(url, parseQueryString)
   url = url:sub((chunk and #chunk or 0) + 1)
 
   local auth
-  chunk, auth = url:match('(([0-9a-zA-Z]+:?[0-9a-zA-Z]+)@)')
+  chunk, auth = url:match('(([%w%p]+:?[%w%p]+)@)')
   url = url:sub((chunk and #chunk or 0) + 1)
 
   local host


### PR DESCRIPTION
This commit allows for punctuation characters in the user and password fields
of auth strings, which provides support for a URL like:

`https://user-name_#01:p@ssw0rd@somedomain.com/`

Closes: #978