### PR TITLE
Release 2.14.1

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@
  - require: Fix bundle requires on Windows [Squeek]
  - Support punctuation in http credentials [Charles Farquhar]
  - Update lit to 3.5.4 [Tim Caswell]
+ - Revert fs change that broke readstreams [Tim Caswell]
 
 # Changes in 2.12.1
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+# Changes in 2.14.1
+
+ - dns: Allow ip addresses in dns resolve to resolve internally. [NiteHawk]
+ - http-codec: Add HTTP status codes of RFC 6585 [Navid]
+ - require: Fix bundle requires on Windows [Squeek]
+ - Support punctuation in http credentials [Charles Farquhar]
+ - Update lit to 3.5.4 [Tim Caswell]
+
 # Changes in 2.12.1
 
  - childprocess: Fix spawn to cleanup correctly (Ryan Phillips)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 APP_FILES=$(shell find . -type f -name '*.lua')
 BIN_ROOT=lit/luvi-binaries/$(shell uname -s)_$(shell uname -m)
-LIT_VERSION=3.4.5
+LIT_VERSION=3.5.4
 
 LUVIT_TAG=$(shell git describe)
 LUVIT_ARCH=$(shell uname -s)_$(shell uname -m)

--- a/deps/dns.lua
+++ b/deps/dns.lua
@@ -20,7 +20,7 @@ limitations under the License.
 -- https://github.com/openresty/lua-resty-dns/blob/master/lib/resty/dns/resolver.lua
 --[[lit-meta
   name = "luvit/dns"
-  version = "2.0.3"
+  version = "2.0.4"
   dependencies = {
     "luvit/dgram@2.0.0",
     "luvit/fs@2.0.0",

--- a/deps/fs.lua
+++ b/deps/fs.lua
@@ -17,7 +17,7 @@ limitations under the License.
 --]]
 --[[lit-meta
   name = "luvit/fs"
-  version = "2.0.2"
+  version = "2.0.3"
   dependencies = {
     "luvit/utils@2.0.0",
     "luvit/path@2.0.0",

--- a/deps/fs.lua
+++ b/deps/fs.lua
@@ -658,17 +658,18 @@ function fs.ReadStream:_read(n)
     end
   end
 
-  local bytes,err = fs.readSync(self.fd, to_read, self.offset)
-  if err then return self:destroy(err) end
-  if #bytes > 0 then
-    self.bytesRead = self.bytesRead + #bytes
-    if self.offset then
-      self.offset = self.offset + #bytes
+  fs.read(self.fd, to_read, self.offset, function(err, bytes)
+    if err then return self:destroy(err) end
+    if #bytes > 0 then
+      self.bytesRead = self.bytesRead + #bytes
+      if self.offset then
+        self.offset = self.offset + #bytes
+      end
+      self:push(bytes)
+    else
+      self:push()
     end
-    self:push(bytes)
-  else
-    self:push()
-  end
+  end)
 end
 function fs.ReadStream:close()
   self:destroy()

--- a/deps/require.lua
+++ b/deps/require.lua
@@ -17,7 +17,7 @@ limitations under the License.
 --]]
 --[[lit-meta
   name = "luvit/require"
-  version = "2.2.0"
+  version = "2.2.1"
   homepage = "https://github.com/luvit/luvit/blob/master/deps/require.lua"
   description = "Luvit's custom require system with relative requires and sane search paths."
   tags = {"luvit", "require"}

--- a/deps/url.lua
+++ b/deps/url.lua
@@ -17,7 +17,7 @@ limitations under the License.
 --]]
 --[[lit-meta
   name = "luvit/url"
-  version = "2.1.0"
+  version = "2.1.1"
   dependencies = {
     "luvit/querystring@2.0.0",
   }

--- a/deps/ustring.lua
+++ b/deps/ustring.lua
@@ -17,7 +17,7 @@ limitations under the License.
 --]]
 --[[lit-meta
   name = "luvit/ustring"
-  version = "2.0.1"
+  version = "2.0.2"
   homepage = "https://github.com/luvit/luvit/blob/master/deps/ustring.lua"
   description = "A light-weight UTF-8 module in pure lua(jit)."
   tags = {"ustring", "utf8", "utf-8", "unicode"}
@@ -30,7 +30,6 @@ local _meta = {}
 
 local strsub = string.sub
 local strbyte = string.byte
-local band = bit.band
 local rshift = bit.rshift
 
 local function chlen(byte)
@@ -51,7 +50,7 @@ end
 ustring.chlen = chlen
 
 function ustring.new(str,allowInvaild)
-    local str = str and tostring(str) or ""
+    str = str and tostring(str) or ""
     local ustr = {}
     local index = 1;
     local append = 0;
@@ -134,7 +133,7 @@ function ustring.uindex2index(ustr,uindex,initrawindex,inituindex)
         end
         return -index
     else
-        local index = (initindex or 1)
+        local index = (inituindex or 1)
         inituindex = inituindex or 1
         for i = inituindex,uindex - 1 do
             index = index + #ustr[i]

--- a/make.bat
+++ b/make.bat
@@ -1,5 +1,5 @@
 @ECHO off
-@SET LIT_VERSION=3.4.5
+@SET LIT_VERSION=3.5.4
 
 IF NOT "x%1" == "x" GOTO :%1
 

--- a/package.lua
+++ b/package.lua
@@ -1,6 +1,6 @@
 return {
   name = "luvit/luvit",
-  version = "2.14.0",
+  version = "2.14.1",
   luvi = {
     version = "2.7.6",
     flavor = "regular",


### PR DESCRIPTION
# Changes in 2.14.1

 - dns: Allow ip addresses in dns resolve to resolve internally. [NiteHawk]
 - http-codec: Add HTTP status codes of RFC 6585 [Navid]
 - require: Fix bundle requires on Windows [Squeek]
 - Support punctuation in http credentials [Charles Farquhar]
 - Update lit to 3.5.4 [Tim Caswell]
