### PR TITLE
Miscellaneous fixes and optimizations

### DIFF
--- a/deps/helpful.lua
+++ b/deps/helpful.lua
@@ -26,34 +26,33 @@ limitations under the License.
 ]]
 
 function string.levenshtein(str1, str2)
-  local len1 = string.len(str1)
-  local len2 = string.len(str2)
-  local matrix = {}
-  local cost
-  -- quick cut-offs to save time
-  if (len1 == 0) then
-    return len2
-  elseif (len2 == 0) then
-    return len1
-  elseif (str1 == str2) then
+
+  -- cost is 0 for equal strings
+  if str1 == str2 then
     return 0
   end
-    -- initialise the base matrix values
-  for i = 0, len1, 1 do
-    matrix[i] = {}
-    matrix[i][0] = i
+
+  local len1 = string.len(str1)
+  local len2 = string.len(str2)
+
+  -- quick cut-offs to save time
+  if len1 == 0 then
+    return len2
+  elseif len2 == 0 then
+    return len1
   end
-  for j = 0, len2, 1 do
+    -- initialise the base matrix values
+  local matrix = {}
+  for i = 0, len1 do
+    matrix[i] = {[0] = i}
+  end
+  for j = 0, len2 do
     matrix[0][j] = j
   end
     -- actual Levenshtein algorithm
-  for i = 1, len1, 1 do
-    for j = 1, len2, 1 do
-      if (str1:byte(i) == str2:byte(j)) then
-        cost = 0
-      else
-        cost = 1
-      end
+  for i = 1, len1 do
+    for j = 1, len2 do
+      local cost = str1:byte(i) == str2:byte(j) and 0 or 1
       matrix[i][j] = math.min(matrix[i-1][j] + 1, matrix[i][j-1] + 1, matrix[i-1][j-1] + cost)
     end
   end

--- a/deps/http-codec.lua
+++ b/deps/http-codec.lua
@@ -109,10 +109,10 @@ local function encoder()
     if item.method then
       local path = item.path
       assert(path and #path > 0, "expected non-empty path")
-      head = { item.method, ' ', item.path, ' HTTP/', version, '\r\n' }
+      head = { item.method .. ' ' .. item.path .. ' HTTP/' .. version .. '\r\n' }
     else
       local reason = item.reason or STATUS_CODES[item.code]
-      head = { 'HTTP/', version, ' ', item.code, ' ', reason, '\r\n' }
+      head = { 'HTTP/' .. version .. ' ' .. item.code .. ' ' .. reason .. '\r\n' }
     end
     for i = 1, #item do
       local key, value = unpack(item[i])

--- a/deps/http-codec.lua
+++ b/deps/http-codec.lua
@@ -109,10 +109,10 @@ local function encoder()
     if item.method then
       local path = item.path
       assert(path and #path > 0, "expected non-empty path")
-      head = { item.method .. ' ' .. item.path .. ' HTTP/' .. version .. '\r\n' }
+      head = { item.method, ' ', item.path, ' HTTP/', version, '\r\n' }
     else
       local reason = item.reason or STATUS_CODES[item.code]
-      head = { 'HTTP/' .. version .. ' ' .. item.code .. ' ' .. reason .. '\r\n' }
+      head = { 'HTTP/', version, ' ', item.code, ' ', reason, '\r\n' }
     end
     for i = 1, #item do
       local key, value = unpack(item[i])

--- a/deps/pretty-print.lua
+++ b/deps/pretty-print.lua
@@ -236,10 +236,14 @@ function dump(value, recurse, nocolor)
   local function process(localValue)
     local typ = type(localValue)
     if typ == 'string' then
-      if string.match(localValue, "'") and not string.match(localValue, '"') then
-        write(dquote .. string.gsub(localValue, '[%c\\\128-\255]', stringEscape) .. dquote2)
+      if string.find(localValue, "'") and not string.find(localValue, '"') then
+        write(dquote)
+        write(string.gsub(localValue, '[%c\\\128-\255]', stringEscape))
+        write(dquote2)
       else
-        write(quote .. string.gsub(localValue, "[%c\\'\128-\255]", stringEscape) .. quote2)
+        write(quote)
+        write(string.gsub(localValue, "[%c\\'\128-\255]", stringEscape))
+        write(quote2)
       end
     elseif typ == 'table' and not seen[localValue] then
       if not recurse then seen[localValue] = true end
@@ -258,12 +262,14 @@ function dump(value, recurse, nocolor)
           nextIndex = k + 1
           process(v)
         else
-          if type(k) == "string" and string.find(k,"^[%a_][%a%d_]*$") then
-            write(colorize("property", k) .. equals)
+          if type(k) == "string" and string.find(k, "^[%a_][%a%d_]*$") then
+            write(colorize("property", k))
+            write(equals)
           else
             write(obracket)
             process(k)
-            write(cbracket .. equals)
+            write(cbracket)
+            write(equals)
           end
           if type(v) == "table" then
             process(v)
@@ -288,7 +294,7 @@ function dump(value, recurse, nocolor)
   end
 
   process(value)
-  local s =  table.concat(output, "")
+  local s = table.concat(output)
   return nocolor and strip(s) or s
 end
 
@@ -300,18 +306,18 @@ function _G.print(...)
   for i = 1, n do
     arguments[i] = tostring(arguments[i])
   end
-  uv.write(stdout, table.concat(arguments, "\t") .. "\n")
+  uv.write(stdout, table.concat(arguments, "\t"))
+  uv.write(stdout, "\n")
 end
 
 function prettyPrint(...)
   local n = select('#', ...)
-  local arguments = { ... }
-
+  local arguments = {...}
   for i = 1, n do
     arguments[i] = dump(arguments[i])
   end
-
-  print(table.concat(arguments, "\t"))
+  uv.write(stdout, table.concat(arguments, "\t"))
+  uv.write(stdout, "\n")
 end
 
 function strip(str)
@@ -331,7 +337,7 @@ if uv.guess_handle(1) == 'tty' then
   if width == 0 then width = 80 end
   -- auto-detect when 16 color mode should be used
   local term = getenv("TERM")
-  if term and (term == 'xterm' or term:match'-256color$') then
+  if term and (term == 'xterm' or term:find'-256color$') then
     defaultTheme = 256
   else
     defaultTheme = 16

--- a/deps/pretty-print.lua
+++ b/deps/pretty-print.lua
@@ -106,7 +106,6 @@ function strip(str)
   return string.gsub(str, '\027%[[^m]*m', '')
 end
 
-
 function loadColors(index)
   if index == nil then index = defaultTheme end
 
@@ -318,10 +317,6 @@ function prettyPrint(...)
   end
   uv.write(stdout, table.concat(arguments, "\t"))
   uv.write(stdout, "\n")
-end
-
-function strip(str)
-  return string.gsub(str, '\027%[[^m]*m', '')
 end
 
 if uv.guess_handle(0) == 'tty' then

--- a/deps/repl.lua
+++ b/deps/repl.lua
@@ -56,7 +56,10 @@ return function (stdin, stdout, greeting)
     end
   })
 
-  if greeting then stdout:write(greeting .. '\n') end
+  if greeting then
+    stdout:write(greeting)
+    stdout:write('\n')
+  end
 
   local c = utils.color
 
@@ -69,7 +72,8 @@ return function (stdin, stdout, greeting)
     for i = 1, results.n do
       results[i] = utils.dump(results[i])
     end
-    stdout:write(table.concat(results, '\t') .. '\n')
+    stdout:write(table.concat(results, '\t'))
+    stdout:write('\n')
   end
 
   local buffer = ''
@@ -99,7 +103,8 @@ return function (stdin, stdout, greeting)
         end
       elseif type(results[1]) == 'string' then
         -- error
-        stdout:write(results[1] .. '\n')
+        stdout:write(results[1])
+        stdout:write('\n')
       else
         -- error calls with non-string message objects will pass through debug.traceback without a stacktrace added
         stdout:write('error with unexpected error message type (' .. type(results[1]) .. '), no stacktrace available\n')
@@ -111,7 +116,8 @@ return function (stdin, stdout, greeting)
         buffer = chunk .. '\n'
         return '>> '
       else
-        stdout:write(err .. '\n')
+        stdout:write(err)
+        stdout:write('\n')
         buffer = ''
       end
     end

--- a/deps/url.lua
+++ b/deps/url.lua
@@ -169,7 +169,7 @@ local function format(parsed)
 
   -- urlencode # and ? characters only
   pathname = string.gsub(pathname, '([?#])', function(c)
-    return string.format('%%%02X', byte(c))
+    return string.format('%%%02X', string.byte(c))
   end)
 
   -- add slashes


### PR DESCRIPTION
- `byte` was undefined in one place in `url.lua`. To stay consistent with the rest of the file, I changed to `string.byte`.
- I don't know how many people rely on `string.levenshtein` or even know that it's there, but I've optimized it in a few places.
- Many of the changes are me nit-picking some concatenations. In `repl.lua`, I moved the newlines to a new write call and in `pretty-print.lua`, I moved the open/close characters to new write calls. This is especially good for writing large strings; I was able to cut garbage creation by about 50% in some cases.
- Also in `pretty-print.lua`, I changed a few `match` calls to `find` (functional equivalency without returning a new string) and changed the final behavior of `prettyPrint` to just write straight to stdout. I don't see any point in passing the args through `print` after they've already been concatenated.
- Finally, in `pretty-print.lua` again, I removed a duplicate `strip` definition.