### PR TITLE
Changes servername from host to hostname

### DIFF
--- a/deps/tls/init.lua
+++ b/deps/tls/init.lua
@@ -78,7 +78,7 @@ local function connect(options, callback)
   callback = callback or function() end
   options = extend({}, DEFAULT_OPTIONS, options or {})
   port = options.port
-  hostname = options.host or options.servername
+  hostname = options.hostname or options.servername
   if not options.servername then
     options.servername = hostname
   end


### PR DESCRIPTION
`hostname` with no port, should be used instead of `host`.

Try GET https://luvit.io:443/ with hostname vs host.

https://nodejs.org/api/tls.html#tls_server_addcontext_hostname_context