### PR TITLE
Adds missing timer clean-up in coroutine sleeper

### DIFF
--- a/deps/timer.lua
+++ b/deps/timer.lua
@@ -82,7 +82,10 @@ Timer.now = uv.now
 
 local function sleep(delay, thread)
   thread = thread or coroutine.running()
-  uv.new_timer():start(delay, 0, function ()
+  local timer = uv.new_timer()
+  uv.timer_start(timer, delay, 0, function ()
+    uv.timer_stop(timer)
+    uv.close(timer)
     return assert(coroutine.resume(thread))
   end)
   return coroutine.yield()


### PR DESCRIPTION
One can test the two versions with the following:

```lua
local uv = require('uv')

local function sleep(delay, thread)
	thread = thread or coroutine.running()
	uv.new_timer():start(delay, 0, function()
		return assert(coroutine.resume(thread))
	end)
	return coroutine.yield()
end

local function sleep2(delay, thread)
	thread = thread or coroutine.running()
	local timer = uv.new_timer()
	timer:start(delay, 0, function()
		uv.timer_stop(timer)
		uv.close(timer)
		return assert(coroutine.resume(thread))
	end)
	return coroutine.yield()
end

coroutine.wrap(function()
	while true do
		for _ = 1, 1000 do -- purposefully call sleep 1000x
			sleep(1) -- change to sleep2 for the fixed version
		end
		collectgarbage()
		print(collectgarbage('count'))
	end
end)()
```

One leaks, the other does not.