### PR TITLE
Adds missing __newindex for require global

### DIFF
--- a/deps/require.lua
+++ b/deps/require.lua
@@ -306,7 +306,7 @@ function Module:require(name)
         return module:require(...)
       end
     }
-    setfenv(fn, setmetatable(global, { __index = _G }))
+    setfenv(fn, setmetatable(global, { __index = _G, __newindex = _G }))
     local ret = fn()
 
     -- Allow returning the exports as well


### PR DESCRIPTION
Not sure if this is considered a breaking change or a fix.

Currently, you cannot set globals without explicitly indexing `_G`
```lua
randomGlobal = 'module global value'
_G.otherGlobal = 'actual global value'
```
By setting the `__newindex` of the module to `_G`, both options become equivalent.