### PR TITLE
Fix appveyor.yml parse error

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,3 @@ test_script:
 artifacts:
     - path: luvit.exe
     - path: lit.exe
-
-notifications:
-    email: true
-    irc: "irc.freenode.org#luvit"


### PR DESCRIPTION
 - The notifications section seems to have been copied from .travis.yml and was never actually doing anything, but now appveyor fails the build due to a parse error