### PR TITLE
Fix http-codec not reading full header when a header has no value

### DIFF
--- a/deps/http-codec.lua
+++ b/deps/http-codec.lua
@@ -204,7 +204,7 @@ local function decoder()
     -- Parse the header lines
     while true do
       local key, value
-      _, offset, key, value = find(chunk, "^([^:\r\n]+): *([^\r\n]+)\r?\n", offset + 1)
+      _, offset, key, value = find(chunk, "^([^:\r\n]+): *([^\r\n]*)\r?\n", offset + 1)
       if not offset then break end
       local lowerKey = lower(key)
 

--- a/deps/http-codec.lua
+++ b/deps/http-codec.lua
@@ -18,7 +18,7 @@ limitations under the License.
 
 --[[lit-meta
   name = "luvit/http-codec"
-  version = "2.0.1"
+  version = "2.0.2"
   homepage = "https://github.com/luvit/luvit/blob/master/deps/http-codec.lua"
   description = "A simple pair of functions for converting between hex and raw strings."
   tags = {"codec", "http"}

--- a/tests/test-http-decoder.lua
+++ b/tests/test-http-decoder.lua
@@ -74,6 +74,22 @@ require('tap')(function (test)
     }, output))
   end)
 
+  test("http client parser with an empty value", function ()
+    local output = testDecoder(decoder, {
+      "HTTP/1.0 200 OK\r\n",
+      "X-Empty-Value:\r\n",
+      "User-Agent: Luvit-Test\r\n\r\n"
+    })
+    p(output)
+    assert(deepEqual({
+      { code = 200, reason = "OK", version = 1.0, keepAlive = false,
+        {"X-Empty-Value", ""},
+        {"User-Agent", "Luvit-Test"}
+      },
+      ""
+    }, output))
+  end)
+
 
   test("http 1.0 Keep-Alive", function ()
     local output = testDecoder(decoder, {


### PR DESCRIPTION
Example: "X-Geo-Block-List:" gets sent by Github gists, and the header pattern would fail and stop reading the header at that line

See luvit/lit#232