### PR TITLE
remove keeplive on listen socket

### DIFF
--- a/deps/net.lua
+++ b/deps/net.lua
@@ -251,7 +251,6 @@ function Socket:listen(queueSize)
   queueSize = queueSize or 128
   function onListen()
     local client = uv.new_tcp()
-    uv.tcp_keepalive(self._handle, true, 60)
     uv.tcp_keepalive(client, true, 60)
     uv.accept(self._handle, client)
     self:emit('connection', Socket:new({ handle = client }))


### PR DESCRIPTION
SO_KEEPALIVE is a TCP concept, but can apply to listen socket.
On Linux/Windows, it will be ignored, but  on macOS, then listen socket will be closed(not trigger any event) after timeout. That will make my server offline. 

This RP will solve this problem.

Cc @creationix 