### PR TITLE
fix ignore tcp errors

### DIFF
--- a/deps/net.lua
+++ b/deps/net.lua
@@ -205,7 +205,7 @@ function Socket:connect(...)
       return self:destroy(err)
     end
     if self.destroyed then return end
-    uv.tcp_connect(self._handle, res[1].addr, res[1].port, function(err)
+    local _, terr = uv.tcp_connect(self._handle, res[1].addr, res[1].port, function(err)
       if err then
         return self:destroy(err)
       end
@@ -214,6 +214,9 @@ function Socket:connect(...)
       self:emit('connect')
       if callback then callback() end
     end)
+    if terr ~= nil then
+      self:destroy(terr)
+    end
   end)
 
   return self


### PR DESCRIPTION
libuv does not allways call the callback passed to uv_tcp_connect with an error: https://github.com/libuv/libuv/blob/v1.9.1/src/unix/tcp.c#L140 If the error occurs when calling socket(2) or connect(2), the error is completely ignored. 

Luv does check for the return value of uv_tcp_connect: https://github.com/luvit/luv/blob/1.9.1-1/src/tcp.c#L188 so this change is sufficient to fix the issue.