### PR TITLE
fix ignore enomem on getaddrinfo

### DIFF
--- a/deps/net.lua
+++ b/deps/net.lua
@@ -199,7 +199,7 @@ function Socket:connect(...)
     self._handle = uv.new_tcp()
   end
 
-  uv.getaddrinfo(options.host, options.port, { socktype = "stream" }, function(err, res)
+  local _, derr = uv.getaddrinfo(options.host, options.port, { socktype = "stream" }, function(err, res)
     timer.active(self)
     if err then
       return self:destroy(err)
@@ -215,6 +215,9 @@ function Socket:connect(...)
       if callback then callback() end
     end)
   end)
+  if derr ~= nil then
+    return self:destroy(derr)
+  end
 
   return self
 end


### PR DESCRIPTION
similar to https://github.com/luvit/luvit/pull/1031 but in this case we're ignoring the errors from uv.getaddrinfo: https://github.com/libuv/libuv/blob/v1.x/src/unix/getaddrinfo.c#L138

In this case, we're already checking that host, port and service are not nulls so the incorrect behaviour is only exhibited if libuv fails to allocate a buffer.