### PR TITLE
adding some simple error handling to the REPL autocomplete.

### DIFF
--- a/deps/repl.lua
+++ b/deps/repl.lua
@@ -135,8 +135,11 @@ return function (stdin, stdout, greeting)
     local scope
     if base then
       local f = loadstring("return " .. base)
+      if not f then return {} end
       setfenv(f, global)
-      scope = f()
+      local ok
+      ok, scope = pcall(f)
+      if not ok then return {} end
     else
       base = ''
       sep = ''


### PR DESCRIPTION
This is a quick fix for issue #1035 making it not crash anymore. Making it successfully autocomplete requires more work.