### PR TITLE
Add cmd files

### DIFF
--- a/lit.cmd
+++ b/lit.cmd
@@ -1,0 +1,21 @@
+@echo off
+setlocal
+
+set home=%~dp0
+set exe=%home%lit.exe
+set bin=%home%lit
+set build=%home%make.bat
+set dir=%CD%
+
+IF NOT EXIST "%exe%" (
+  cd "%home%" && CALL make && cd "%dir%"
+)
+
+IF NOT EXIST "%bin%" (
+  CALL del /Q "%home%luvit" "%home%luvi" "%home%lit"
+  CALL mklink "%home%luvit" "%home%luvit.exe"
+  CALL mklink "%home%luvi" "%home%luvi.exe"
+  CALL mklink "%home%lit" "%home%lit.exe"
+)
+
+CALL "%bin%" %*

--- a/luvi.cmd
+++ b/luvi.cmd
@@ -1,0 +1,21 @@
+@echo off
+setlocal
+
+set home=%~dp0
+set exe=%home%luvi.exe
+set bin=%home%luvi
+set build=%home%make.bat
+set dir=%CD%
+
+IF NOT EXIST "%exe%" (
+  cd "%home%" && CALL make && cd "%dir%"
+)
+
+IF NOT EXIST "%bin%" (
+  CALL del /Q "%home%luvit" "%home%luvi" "%home%lit"
+  CALL mklink "%home%luvit" "%home%luvit.exe"
+  CALL mklink "%home%luvi" "%home%luvi.exe"
+  CALL mklink "%home%lit" "%home%lit.exe"
+)
+
+CALL "%bin%" %*

--- a/luvit.cmd
+++ b/luvit.cmd
@@ -1,0 +1,21 @@
+@echo off
+setlocal
+
+set home=%~dp0
+set exe=%home%luvit.exe
+set bin=%home%luvit
+set build=%home%make.bat
+set dir=%CD%
+
+IF NOT EXIST "%exe%" (
+  cd "%home%" && CALL make && cd "%dir%"
+)
+
+IF NOT EXIST "%bin%" (
+  CALL del /Q "%home%luvit" "%home%luvi" "%home%lit"
+  CALL mklink "%home%luvit" "%home%luvit.exe"
+  CALL mklink "%home%luvi" "%home%luvi.exe"
+  CALL mklink "%home%lit" "%home%lit.exe"
+)
+
+CALL "%bin%" %*


### PR DESCRIPTION
I'm trying to get `npx luvit` working on Windows. The [node-luvit/package.json](https://github.com/shawwn/node-luvit/blob/0312588703c0c81b9a32a9eb1c17316ec49c4200/package.json#L8-L18) looks like this:

```
  "scripts": {
    "preinstall": "cd luvit && make luvit",
    "install": "cd luvit && make luvit",
    "postinstall": "cd luvit && make luvit",
    "prepublish": "cd luvit && make clean"
  },
  "bin": {
    "luvit": "./luvit/luvit",
    "luvi": "./luvit/luvi",
    "lit": "./luvit/lit"
  },
```

These `bin` paths fail on Windows because the correct path is `./luvit/luvit.exe`.

The .cmd scripts help solve the issue because I can change the install scripts to `cd luvit && luvit --version`, which ensures `./luvit/luvit` is symlinked to `./luvit/luvit.exe` using `mklink`.

