### PR TITLE
Match only past last . in file extensions

### DIFF
--- a/deps/require.lua
+++ b/deps/require.lua
@@ -287,7 +287,7 @@ function Module:require(name)
   module = makeModule(path)
   moduleCache[key] = module
 
-  local ext = path:match("%.[^/\\]+$")
+  local ext = path:match("%.[^/\\%.]+$")
   if ext == ".lua" then
     local match = path:match("^bundle:(.*)$")
     if match then


### PR DESCRIPTION
allows files such as file.test.lua and file.something.else.lua to both be required without an unknown type error