### PR TITLE
Add uncaughtException handler

### DIFF
--- a/deps/process.lua
+++ b/deps/process.lua
@@ -87,7 +87,7 @@ end
 local signalWraps = {}
 
 local function on(self, _type, listener)
-  if _type == "error" or _type == "exit" then
+  if _type == "error" or _type == "uncaughtException" or _type == "exit" then
     Emitter.on(self, _type, listener)
   else
     if not signalWraps[_type] then
@@ -212,6 +212,7 @@ local function globalProcess()
   process.stdout = UvStreamWritable:new(pp.stdout)
   process.stderr = UvStreamWritable:new(pp.stderr)
   hooks:on('process.exit', utils.bind(process.emit, process, 'exit'))
+  hooks:on('process.uncaughtException', utils.bind(process.emit, process, 'uncaughtException'))
   return process
 end
 

--- a/init.lua
+++ b/init.lua
@@ -50,7 +50,10 @@ return function (main, ...)
 
     -- Start the event loop
     uv.run()
-  end, debug.traceback)
+  end, function(err)
+    require('hooks'):emit('process.uncaughtException',err)
+    return debug.traceback(err)
+  end)
 
   if success then
     -- Allow actions to run at process exit.


### PR DESCRIPTION
Similar to https://nodejs.org/api/process.html#process_event_uncaughtexception and the crash stack can also be observed.

I will need to add a test case and see if there is a better way to implement this.