### PR TITLE
 Fix http-codec failing occasionally during chunked decoding 

### DIFF
--- a/deps/http-codec.lua
+++ b/deps/http-codec.lua
@@ -251,7 +251,11 @@ local function decoder()
     local len, term
     len, term = match(chunk, "^(%x+)(..)")
     if not len then return end
-    assert(term == "\r\n")
+    if term ~= "\r\n" then
+      if #chunk < 34 then return end
+      -- But protect against evil clients by refusing chunk-sizes longer than 32 hex digits.
+      error("chunk-size field too large")
+    end
     local length = tonumber(len, 16)
     if #chunk < length + 4 + #len then return end
     if length == 0 then

--- a/deps/http-codec.lua
+++ b/deps/http-codec.lua
@@ -18,7 +18,7 @@ limitations under the License.
 
 --[[lit-meta
   name = "luvit/http-codec"
-  version = "2.0.2"
+  version = "2.0.3"
   homepage = "https://github.com/luvit/luvit/blob/master/deps/http-codec.lua"
   description = "A simple pair of functions for converting between hex and raw strings."
   tags = {"codec", "http"}

--- a/deps/http-codec.lua
+++ b/deps/http-codec.lua
@@ -252,8 +252,9 @@ local function decoder()
     len, term = match(chunk, "^(%x+)(..)")
     if not len then return end
     if term ~= "\r\n" then
-      if #chunk < 34 then return end
-      -- But protect against evil clients by refusing chunk-sizes longer than 32 hex digits.
+      -- Wait for full chunk-size\r\n header
+      if #chunk < 18 then return end
+      -- But protect against evil clients by refusing chunk-sizes longer than 16 hex digits.
       error("chunk-size field too large")
     end
     local length = tonumber(len, 16)

--- a/tests/test-http-decoder.lua
+++ b/tests/test-http-decoder.lua
@@ -226,7 +226,8 @@ require('tap')(function (test)
       "PUT /my-file.txt HTTP/1.1\r",
       "\nTransfer-Encoding: chunke",
       "d\r\n\r\n4\r\nWiki\r\n5\r\n",
-      "pedia\r\ne\r\n in\r\n\r\nch",
+      "pedia\r\n12\r",
+      "\n in broken ch",
       "unks.\r\n0\r\n\r\n"
     })
     p(output)
@@ -236,7 +237,7 @@ require('tap')(function (test)
       },
       "Wiki",
       "pedia",
-      " in\r\n\r\nchunks.",
+      " in broken chunks.",
       ""
     }, output))
   end)


### PR DESCRIPTION
It is not guaranteed that the data we have received so far will include both the chunk-size and its terminator, so failing in that case is wrong. Instead, we should wait until we get more data and check again. This commit makes it so that decoding only fails if we still don't find a terminator with a chunk-size field of >= 32 hex digits, which should never happen under normal circumstances.

Detailed example of when this can occur:

- Data received so far: `'4\r\nTest\r\n13\r'`
- First chunk decoded: len=`'4'`, data=`'Test'`
- Data remaining to decode: `'13\r'`
- Attempt to decode next chunk: len=`'1'`, term=`'3\r'`; term ~= `'\r\n'` (without this commit, the code would error here with a failed assert)
- New data received: `'\nFixed in this case\r\n'`
- Data remaining to decode: `'13\r\nFixed in this case\r\n'`
- Re-attempt to decode chunk: len=`'13'`, data=`'Fixed in this case'`