### PR TITLE
make luvit not collectgarbage manually

### DIFF
--- a/deps/http.lua
+++ b/deps/http.lua
@@ -189,7 +189,6 @@ function ServerResponse:finish(chunk)
     self:emit('finish')
     if not self.keepAlive then
       self.socket:_end()
-      collectgarbage()
     end
   end
   if #last > 0 then


### PR DESCRIPTION
Lua VM will auto perform garbage-collection, if need user of luvit lib
can call collectgarbage when some event fired.