### PR TITLE
childprocess: Fix exec on Windows

### DIFF
--- a/deps/childprocess.lua
+++ b/deps/childprocess.lua
@@ -137,7 +137,8 @@ local function spawn(command, args, options)
     env = envPairs,
     detached = options.detached,
     uid = options.uid,
-    gid = options.gid
+    gid = options.gid,
+    verbatim = options.verbatim,
   }, onExit)
 
   em = Process:new(stdin, stdout, stderr)
@@ -181,6 +182,8 @@ local function normalizeExecArgs(command, options, callback)
   if isWindows then
     file = 'cmd.exe'
     args = {'/s', '/c', '"'..command..'"'}
+    -- verbatim is necessary to avoid quotation marks getting escaped by Libuv
+    options.verbatim = true
   else
     file = '/bin/sh'
     args = {'-c', command}


### PR DESCRIPTION
Without specifiying verbatim=true, `exec` calls would fail with an error like

```
 '\"cmd.exe\"' is not recognized as an internal or external command,
 operable program or batch file.
```

because Libuv would try to escape the double quotes, but no escaping should be done when using `cmd.exe /s /c`

Relevant links:
- http://docs.libuv.org/en/v1.x/process.html#c.uv_process_flags
- https://stackoverflow.com/questions/9866962/what-is-cmd-s-for