### PR TITLE
fix unclosed handle in childprocess module

### DIFF
--- a/deps/childprocess.lua
+++ b/deps/childprocess.lua
@@ -126,6 +126,7 @@ local function spawn(command, args, options)
     em.exitCode = code
     em.signal = signal
     em:emit('exit', code, signal)
+    if stdin then stdin:destroy(maybeClose) end
     maybeClose()
     em:close()
   end


### PR DESCRIPTION
When a spawned child process exit, stdout and stderr will be closed as expected, but stdin keep open, and not fire close event. This because stdout and stderr care read event, close when EOF, but stdin as write pipe, that don't get error when not data to output, so need to close stdin explicitly. 
This will make all CI pass.