### PR TITLE
update ssl to support session reuse for TLSV1.3

### DIFF
--- a/deps/tls/init.lua
+++ b/deps/tls/init.lua
@@ -40,15 +40,11 @@ function Server:init(options, connectionListener)
   options = options or {}
   options.server = true
 
-  local sharedCreds = _common_tls.createCredentials(options)
+  options.secureContext = options.secureContext
+                          or _common_tls.createCredentials(options)
   net.Server.init(self, options, function(raw_socket)
     local socket
-    socket = _common_tls.TLSSocket:new(raw_socket, {
-      secureContext = sharedCreds,
-      isServer = true,
-      requestCert = options.requestCert,
-      rejectUnauthorized = options.rejectUnauthorized,
-    })
+    socket = _common_tls.TLSSocket:new(raw_socket, options)
     socket:on('secureConnection', function()
       connectionListener(socket)
     end)
@@ -77,6 +73,7 @@ local function connect(options, callback)
 
   callback = callback or function() end
   options = extend({}, DEFAULT_OPTIONS, options or {})
+  options.server = false
   port = options.port
   hostname = options.host or options.hostname
   colon = hostname:find(':')

--- a/tests/test-tls-connect-session-reuse.lua
+++ b/tests/test-tls-connect-session-reuse.lua
@@ -3,6 +3,7 @@ require('tap')(function (test)
   local fixture = require('./fixture-tls')
   local tls = require('tls')
   local timer = require('timer')
+  local openssl = require('openssl')
   local options = {
     cert = fixture.certPem,
     key = fixture.keyPem
@@ -13,18 +14,26 @@ require('tap')(function (test)
 
   local server
   local client1, client2
-  local session1,session2
+  local session0,session1,session2,session3
   local conns={}
   test("tls connect session reuse test", function()
     server = tls.createServer(options, function(conn)
       serverConnected = serverConnected + 1
       p('server accepted',serverConnected)
       conns[serverConnected] = conn
+      conn:write('done\n')
       if (serverConnected == 2) then
         timer.setTimeout(1000,function()
           server:close()
           p('server closed')
-          assert(session1:id()==session2:id())
+          if conn:version()~='TLSv1.3' then
+            -- TLSv1.3 change the session id
+            assert(session0:id()==session1:id())
+            assert(session1:id()==session2:id())
+            assert(session2:id()==session3:id())
+          else
+            assert(session1:id()==session2:id())
+          end
           conns[1]:destroy()
           conns[2]:destroy()
           client1:destroy()
@@ -35,7 +44,6 @@ require('tap')(function (test)
 
     server:listen(fixture.commonPort, function()
       p('server listening at:',fixture.commonPort)
-
       local options = {
         port = fixture.commonPort,
         host = '127.0.0.1',
@@ -46,29 +54,37 @@ require('tap')(function (test)
       local calltwo
       client1 = tls.connect(options)
       client1:on('secureConnection', function()
-        session1 = client1.ssl:session()
-        assert(client1.ssl:session_reused()==false)
-        p('client connected')
+        p('client1 connected')
         clientConnected = clientConnected + 1
-        session1 = client1.ctx.session
-        timer.setTimeout(500,calltwo)
+        session0 = client1.ssl:session()
+        print('SESSIONID0:', openssl.hex(session0:id()))
       end)
 
       client1:on('error', function(err)
         p(err)
         client1:destroy()
       end)
+      client1:on('data', function(...)
+        p(...)
+        session1 = client1.ssl:session()
+        options.secureContext.session = session1
+        print('SESSIONID1:', openssl.hex(session1:id()))
+        assert(client1.ssl:session_reused()==false)
+        timer.setTimeout(100, calltwo)
+      end)
       client1:on('end', function()
         p('client end')
       end)
 
       calltwo = function()
+        p(options)
         client2 = tls.connect(options)
         client2:on('secureConnection', function()
-          session2 = client2.ssl:session()
-          assert(client2.ssl:session_reused()==true)
           p('client2 connected')
           clientConnected = clientConnected + 1
+          session2 = client2.ssl:session()
+          print('SESSIONID2:', openssl.hex(session2:id()))
+          assert(client2.ssl:session_reused()==true)
         end)
         client2:on('error', function(err)
           p(err)
@@ -77,8 +93,12 @@ require('tap')(function (test)
         client2:on('end', function()
           p('client end')
         end)
+        client2:on('data', function(...)
+          p(...)
+          session3 = client2.ssl:session()
+          print('SESSIONID3:', openssl.hex(session3:id()))
+        end)
       end
-      --]]
     end)
   end)
 end)


### PR DESCRIPTION
Ths is just a intermediate state. The final solution need wait lua-openssl/luvi upgrade.

https://wiki.openssl.org/index.php/TLS1.3#Sessions says 

>  In TLSv1.3 sessions are not established until after the main handshake has completed. The server sends a separate post-handshake message to the client containing the session details. Typically this will happen soon after the handshake has completed, but it could be sometime later (or not at all).

> The old SSL_get1_session() and similar APIs may not operate as expected for client applications written for TLSv1.2 and below. Specifically if a client application calls SSL_get1_session() before the server message containing session details has been received then an SSL_SESSION object will still be returned, but any attempt to resume with it will not succeed and a full handshake will occur instead. In the case where multiple sessions have been sent by the server then only the last session will be returned by SSL_get1_session(). Calling SSL_get1_session() after a 2 way shutdown will give a resumable session if any was sent. You can check that a session is resumable with SSL_SESSION_is_resumable().

> Client application developers should consider using the SSL_CTX_sess_set_new_cb() API instead. This provides a callback mechanism which gets invoked every time a new session is established. This can get invoked multiple times for a single connection if a server sends multiple session messages.

> Note that SSL_CTX_sess_set_new_cb() was also available in previous versions of OpenSSL. Applications that already used that API will still work, but they may find that the callback is invoked at unexpected times, i.e. post-handshake.

> An OpenSSL server will immediately attempt to send session details to a client after the main handshake has completed. The number of tickets can be set using SSL_CTX_set_num_tickets. To server applications this post-handshake stage will appear to be part of the main handshake, so calls to SSL_get1_session() should continue to work as before.

> If a client sends it's data and directly sends the close notify request and closes the connection, the server will still try to send tickets if configured to do so. Since the connection is already closed by the client, this might result in a write error and receiving the SIGPIPE signal. The write error will be ignored if it's a session ticket. But server applications can still get SIGPIPE they didn't get before.