### PR TITLE
emitter: fix removeAllListeners

### DIFF
--- a/deps/core.lua
+++ b/deps/core.lua
@@ -285,10 +285,12 @@ end
 function Emitter:removeAllListeners(name)
   local handlers = rawget(self, "handlers")
   if not handlers then return end
-  local handlers_for_type = rawget(handlers, name)
-  if handlers_for_type then
-    for i = #handlers_for_type, 1, -1 do
-        handlers_for_type[i] = false
+  if name then
+    local handlers_for_type = rawget(handlers, name)
+    if handlers_for_type then
+      for i = #handlers_for_type, 1, -1 do
+          handlers_for_type[i] = false
+      end
     end
   else
     rawset(self, "handlers", {})

--- a/tests/test-emitter.lua
+++ b/tests/test-emitter.lua
@@ -72,12 +72,32 @@ require('tap')(function (test)
 
   test("remove all listeners", function(expect)
     local em = require('core').Emitter:new()
+
     em:on('data', function() end)
     em:removeAllListeners()
+
     em:on('data', expect(function() end))
     em:emit('data', 'Go Fish')
-    assert(#em:listeners('data') == 1)
+
+    em:on('event', function() end)
+    em:on('event', function() end)
+
+    assert(em:listenerCount('data') == 1)
+    assert(em:listenerCount('event') == 2)
+
+    em:removeAllListeners('data')
+
+    assert(em:listenerCount('data') == 0)
+    assert(em:listenerCount('event') == 2)
+
+    em:removeAllListeners('unused_listener')
+
+    assert(em:listenerCount('data') == 0)
+    assert(em:listenerCount('event') == 2)
+
     em:removeAllListeners()
-    assert(#em:listeners('data') == 0)
+
+    assert(em:listenerCount('data') == 0)
+    assert(em:listenerCount('event') == 0)
   end)
 end)


### PR DESCRIPTION
If removeAllListeners was called with an event name that wasn't used, it would remove all listeners from every event.