### PR TITLE
fix: remove extra argument to doWrite call

### DIFF
--- a/deps/stream/stream_writable.lua
+++ b/deps/stream/stream_writable.lua
@@ -412,7 +412,7 @@ function clearBuffer(stream, state)
     // TODO(isaacs) clean this up
     --]]
     state.pendingcb = state.pendingcb + 1
-    doWrite(stream, state, true, state.length, state.buffer, '', function(err)
+    doWrite(stream, state, true, state.length, state.buffer, function(err)
       for i = 1,table.getn(cbs) do
         state.pendingcb = state.pendingcb - 1
         cbs[i](err)


### PR DESCRIPTION
The current implementation passes in an empty string as the node implementation does for an encoding parameter. In luvit there is no encoding parameter, so this should not be passed.