### PR TITLE
Fix abort when redirecting stdout/stderr to file

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -64,13 +64,21 @@ return function (main, ...)
     require('pretty-print').stderr:write("Uncaught exception:\n" .. err .. "\n")
   end
 
+  local function isFileHandle(handle, name, fd)
+    return _G.process[name].handle == handle and uv.guess_handle(fd) == 'file'
+  end
+  local function isStdioFileHandle(handle)
+    return isFileHandle(handle, 'stdin', 0) or isFileHandle(handle, 'stdout', 1) or isFileHandle(handle, 'stderr', 2)
+  end
   -- When the loop exits, close all unclosed uv handles (flushing any streams found).
   uv.walk(function (handle)
     if handle then
       local function close()
         if not handle:is_closing() then handle:close() end
       end
-      if handle.shutdown then
+      -- The isStdioFileHandle check is a hacky way to avoid an abort when a stdio handle is a pipe to a file
+      -- TODO: Fix this in a better way, see https://github.com/luvit/luvit/issues/1094
+      if handle.shutdown and not isStdioFileHandle(handle) then
         handle:shutdown(close)
       else
         close()


### PR DESCRIPTION
This is a hacky band-aid fix for a bigger problem that needs a more comprehensive solution. See https://github.com/luvit/luvit/issues/1094

Closes #1083, does not affect #1023