### PR TITLE
Mitigate bogus errors being returned on stack overflows

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -51,7 +51,10 @@ return function (main, ...)
     -- Start the event loop
     uv.run()
   end, function(err)
-    require('hooks'):emit('process.uncaughtException',err)
+    -- During a stack overflow error, this can fail due to exhausting the remaining stack.
+    -- We can't recover from that failure, but wrapping it in a pcall allows us to still
+    -- return the stack overflow error even if the 'process.uncaughtException' fails to emit
+    pcall(function() require('hooks'):emit('process.uncaughtException',err) end)
     return debug.traceback(err)
   end)
 


### PR DESCRIPTION
This is one possible way to fix #1101, although it means that some stack overflow errors would never get emitted via 'process.uncaughtException'. The alternative would be to reduce the amount of work that needs to be done for emitting 'process.uncaughtException' in order to avoid the stack exhaustion.

Closes #1101

Before:

```
Uncaught exception:
([^/\]+)
```

After:

```
Uncaught exception:
C:\Users\Ryan\Programming\Luvit\luvit\test.lua:2: stack overflow
stack traceback:
        C:\Users\Ryan\Programming\Luvit\luvit\test.lua:2: in function 'test'
        C:\Users\Ryan\Programming\Luvit\luvit\test.lua:2: in function 'test'
        C:\Users\Ryan\Programming\Luvit\luvit\test.lua:2: in function 'test'
        C:\Users\Ryan\Programming\Luvit\luvit\test.lua:2: in function 'test'
        C:\Users\Ryan\Programming\Luvit\luvit\test.lua:2: in function 'test'
        C:\Users\Ryan\Programming\Luvit\luvit\test.lua:2: in function 'test'
        C:\Users\Ryan\Programming\Luvit\luvit\test.lua:2: in function 'test'
        C:\Users\Ryan\Programming\Luvit\luvit\test.lua:2: in function 'test'
        C:\Users\Ryan\Programming\Luvit\luvit\test.lua:2: in function 'test'
        C:\Users\Ryan\Programming\Luvit\luvit\test.lua:2: in function 'test'
        C:\Users\Ryan\Programming\Luvit\luvit\test.lua:2: in function 'test'
        ...
        C:\Users\Ryan\Programming\Luvit\luvit\test.lua:2: in function 'test'
        C:\Users\Ryan\Programming\Luvit\luvit\test.lua:2: in function 'test'
        C:\Users\Ryan\Programming\Luvit\luvit\test.lua:2: in function 'test'
        C:\Users\Ryan\Programming\Luvit\luvit\test.lua:5: in function 'fn'
        [string "bundle:deps/require.lua"]:310: in function 'require'
        C:\Users\Ryan\Programming\Luvit\luvit\main.lua:118: in function 'main'
        C:\Users\Ryan\Programming\Luvit\luvit\init.lua:49: in function <C:\Users\Ryan\Programming\Luvit\luvit\init.lua:47>
        [C]: in function 'xpcall'
        C:\Users\Ryan\Programming\Luvit\luvit\init.lua:47: in function 'fn'
        [string "bundle:deps/require.lua"]:310: in function <[string "bundle:deps/require.lua"]:266>
```