### PR TITLE
Signal removeListener fixes

### DIFF
--- a/deps/core.lua
+++ b/deps/core.lua
@@ -256,7 +256,9 @@ function Emitter:emit(name, ...)
 end
 
 -- Remove a listener so that it no longer catches events.
+-- Returns the number of listeners removed, or nil if none were removed
 function Emitter:removeListener(name, callback)
+  local num_removed = 0
   local handlers = rawget(self, "handlers")
   if not handlers then return end
   local handlers_for_type = rawget(handlers, name)
@@ -271,13 +273,16 @@ function Emitter:removeListener(name, callback)
       end
       if h then
         handlers_for_type[i] = false
+        num_removed = num_removed + 1
       end
     end
   else
     for i = #handlers_for_type, 1, -1 do
       handlers_for_type[i] = false
+      num_removed = num_removed + 1
     end
   end
+  return num_removed > 0 and num_removed or nil
 end
 
 -- Remove all listeners


### PR DESCRIPTION
Something I noticed while looking into #1099

> Before this, calling removeListener would unconditionally close the signal, even if there were other listeners still listening for that signal type. Now, the signal will only be closed once there are no listeners left.

---

This will conflict with https://github.com/luvit/luvit/pull/1114 and https://github.com/luvit/luvit/pull/1112. I'll fix the conflicts once those are merged.