### PR TITLE
tls: Fix for OpenSSL 1.1.0

### DIFF
--- a/deps/tls/common.lua
+++ b/deps/tls/common.lua
@@ -40,7 +40,7 @@ local isTLSv1_3 = function()
   end
 
   local _, _, V = openssl.version(true)
-  return V > 0x10100000
+  return V >= 0x10101000
 end
 
 DEFAULT_CIPHERS = 'TLS_AES_128_GCM_SHA256:TLS_AES_128_CCM_SHA256:' .. --TLS 1.3

--- a/deps/tls/package.lua
+++ b/deps/tls/package.lua
@@ -1,6 +1,6 @@
 return {
   name = "luvit/tls",
-  version = "2.3.0",
+  version = "2.3.1",
   dependencies = {
     "luvit/core@2.0.0",
     "luvit/net@2.0.0",


### PR DESCRIPTION
Same fix as https://github.com/luvit/lit/pull/272 but for the Luvit tls package

What was happening is that the OpenSSL version gets incremented with each patch version, so 1.1.0 would be 0x1010000f while 1.1.0a would be 0x1010001f, so the > 0x10100000 check was unintentionally passing for all 1.1.0 versions except 1.1.0-dev. It should be checking for >= 1.1.1 instead, which is when TLSv1.3 support was added to OpenSSL (https://www.openssl.org/news/openssl-1.1.1-notes.html)