### PR TITLE
Adds and uses utils.assertResume

### DIFF
--- a/deps/timer.lua
+++ b/deps/timer.lua
@@ -20,7 +20,7 @@ limitations under the License.
   version = "2.0.1"
   dependencies = {
     "luvit/core@2.0.0",
-    "luvit/utils@2.0.0",
+    "luvit/utils@2.1.0",
   }
   license = "Apache 2"
   homepage = "https://github.com/luvit/luvit/blob/master/deps/timer.lua"
@@ -31,6 +31,7 @@ limitations under the License.
 local uv = require('uv')
 local Object = require('core').Object
 local bind = require('utils').bind
+local assertResume = require('utils').assertResume
 
 -------------------------------------------------------------------------------
 
@@ -86,7 +87,7 @@ local function sleep(delay, thread)
   uv.timer_start(timer, delay, 0, function ()
     uv.timer_stop(timer)
     uv.close(timer)
-    return assert(coroutine.resume(thread))
+    return assertResume(thread)
   end)
   return coroutine.yield()
 end

--- a/deps/utils.lua
+++ b/deps/utils.lua
@@ -18,7 +18,7 @@ limitations under the License.
 
 --[[lit-meta
   name = "luvit/utils"
-  version = "2.0.0"
+  version = "2.1.0"
   dependencies = {
     "luvit/pretty-print@2.0.0",
   }
@@ -33,6 +33,13 @@ local utils = {}
 local pp = require('pretty-print')
 for name, value in pairs(pp) do
   utils[name] = value
+end
+
+local function assertResume(thread, ...)
+  local success, err = coroutine.resume(thread, ...)
+  if not success then
+    error(debug.traceback(thread, err), 0)
+  end
 end
 
 local function bind(fn, self, ...)
@@ -82,9 +89,9 @@ local function adapt(c, fn, ...)
   args[nargs + 1] = function (e, ...)
     if waiting then
       if e then
-        assert(coroutine.resume(c, nil, e))
+        assertResume(c, nil, e)
       else
-        assert(coroutine.resume(c, ...))
+        assertResume(c, ...)
       end
     else
       err, data = e and Error:new(e), {...}
@@ -94,7 +101,7 @@ local function adapt(c, fn, ...)
   fn(unpack(args))
   if c then
     waiting = true
-    return coroutine.yield(c)
+    return coroutine.yield()
   elseif err then
     return nil, err
   else
@@ -105,5 +112,6 @@ end
 utils.bind = bind
 utils.noop = noop
 utils.adapt = adapt
+utils.assertResume = assertResume
 
 return utils


### PR DESCRIPTION
This adds a utility to luvit that fixes the issue of missing stack traces described at luvit/lit#273, related to the fix at luvit/lit#276.

This also bumps the individual library versions. It does not bump the luvit version or its dependencies.