### PR TITLE
ustring.lua: empty string ~= empty list

### DIFF
--- a/deps/ustring.lua
+++ b/deps/ustring.lua
@@ -225,20 +225,8 @@ end
 _meta.__index = ustring
 
 function _meta.__eq(ustr1,ustr2)
-    local len1 = #ustr1
-    local len2 = #ustr2
-    if len1 ~= len2 then return false end
-
-    for i = 1,len1 do
-        if ustr1[i] ~= ustr2[i] then return false end
-    end
-
-    if len1 == 0 and len2 == 0 then
-        if getmetatable(ustr1) ~= getmetatable(ustr2) then
-            return false
-        end
-    end
-    return true
+    if #ustr1 ~= #ustr2 then return false end
+    return tostring(ustr1) == tostring(ustr2)
 end
 
 function _meta.__tostring(self)

--- a/deps/ustring.lua
+++ b/deps/ustring.lua
@@ -232,6 +232,12 @@ function _meta.__eq(ustr1,ustr2)
     for i = 1,len1 do
         if ustr1[i] ~= ustr2[i] then return false end
     end
+
+    if len1 == 0 and len2 == 0 then
+        if getmetatable(ustr1) ~= getmetatable(ustr2) then
+            return false
+        end
+    end
     return true
 end
 


### PR DESCRIPTION
On Lua 5.3.5, `ustring.new("") == {}`

This is rather unexpected behavior, so this PR fixes it by ensuring both types are the same.

(I'm open to suggestions on how better to fix this.)