### PR TITLE
Localize p in stream_readable.lua.

### DIFF
--- a/deps/stream/stream_readable.lua
+++ b/deps/stream/stream_readable.lua
@@ -221,7 +221,7 @@ function roundUpToNextPowerOf2(n)
     n = MAX_HWM
   else
     n = n - 1
-    p = 1
+    local p = 1
     while p < 32 do
       n = bit.bor(n, bit.rshift(n, p))
       p = bit.lshift(p, 1)


### PR DESCRIPTION
Fix an issue in stream_readable.lua where roundUpToNextPowerOf2() overrides the global variable p (which is also in fact, less efficient than using local variable).

Not sure if it does impact any project there.