### PR TITLE
Wrap main in a coroutine

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -45,8 +45,8 @@ return function (main, ...)
 
   local args = {...}
   local success, err = xpcall(function ()
-    -- Call the main app
-    main(unpack(args))
+    -- Call the main app inside a coroutine
+    coroutine.wrap(main)(unpack(args))
 
     -- Start the event loop
     uv.run()


### PR DESCRIPTION
This is technically a breaking change, so I'd like to see whether this has to wait until Luvit 3 (if it ever exists) or if it'll make it into Luvit 2.x.

However, this change allows for running libraries like coro-http without having to wrap an entire file in a coroutine.

### Changes

* The second return of `coroutine.running` is now `false` in any mainland code, the main thread is (mostly) inaccessible.
* `coroutine.yield` will now work successfully instead of throwing a C-call boundary error in mainland code.