### PR TITLE
Release Prep for Luvit v2.18.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,25 @@
+# Changes in 2.18.0
+
+- luvi: bump to v2.12.0 [Tim Caswell]
+- lit: update to 3.8.5 [Tim Caswell]
+- luvit: add the changelog [Tim Caswell]
+- Wrap main in a coroutine [@truemedian]
+
+# Changes in 2.17.1
+
+- http: ignore upgrade header when no upgrade listener is present [Timothy Van Wonterghem]
+- Mitigate bogus errors being returned on stack overflows [Ryan Liptak]
+- Make console/tty write safe [George Zhao]
+- Add Socket:{getSend,getRecv,setSend\,setRecv}BufferSize() [George Zhao]
+- simplify the logic of Emitter:listeners [George Zhao]
+- core: Make Emitter:removeListener return the number of removed handlers [Ryan Liptak]
+- process: Fix signals being closed before all their listeners are removed [Ryan Liptak]
+- Fix luvit argument handling [George Zhao]
+- tls: Fix for OpenSSL 1.1.0 [Ryan Liptak]
+- Add utils.assertResume [SinisterRectus]
+- Localize p in stream_readable.lua [Astie Teddy]
+
+
 # Changes in 2.17.0
 
 - luvi: bump to v2.10.1

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 APP_FILES=$(shell find . -type f -name '*.lua')
 BIN_ROOT=lit/luvi-binaries/$(shell uname -s)_$(shell uname -m)
-LIT_VERSION=3.8.1
+LIT_VERSION=3.8.5
 
 LUVIT_TAG=$(shell git describe)
 LUVIT_ARCH=$(shell uname -s)_$(shell uname -m)

--- a/make.bat
+++ b/make.bat
@@ -1,5 +1,5 @@
 @ECHO off
-@SET GET_LIT_VERSION=3.8.1
+@SET GET_LIT_VERSION=3.8.5
 
 IF NOT "x%1" == "x" GOTO :%1
 

--- a/package.lua
+++ b/package.lua
@@ -1,8 +1,8 @@
 return {
   name = "luvit/luvit",
-  version = "2.17.1",
+  version = "2.18.0",
   luvi = {
-    version = "2.10.1",
+    version = "2.12.0",
     flavor = "regular",
   },
   license = "Apache 2",

--- a/tests/test-colors.lua
+++ b/tests/test-colors.lua
@@ -23,7 +23,7 @@ local strip = utils.strip
 require('tap')(function (test)
 
   test("Recursive values", function ()
-    local data = {a="value"}
+    local data = { a = 'value' }
     data.data = data
     local out = dump(data)
     local stripped = strip(out)


### PR DESCRIPTION
- luvi: bump to v2.12.0 [Tim Caswell]
- lit: update to 3.8.5 [Tim Caswell]
- luvit: add the changelog [Tim Caswell]
- Wrap main in a coroutine [@truemedian]
