### PR TITLE
Remove freenode badge from readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3,7 +3,6 @@
 [![Linux Build Status](https://travis-ci.org/luvit/luvit.svg?branch=master)](https://travis-ci.org/luvit/luvit)
 [![Windows Build status](https://ci.appveyor.com/api/projects/status/72ccr146fm51k7up/branch/master?svg=true)](https://ci.appveyor.com/project/racker-buildbot/luvit/branch/master)
 [![Coverage Status](https://coveralls.io/repos/github/luvit/luvit/badge.svg?branch=master)](https://coveralls.io/github/luvit/luvit?branch=master)
-[![#luvit on Freenode](https://raster.shields.io/badge/Freenode-%23luvit-undefined.png)](https://webchat.freenode.net/?channels=luvit)
 
 
 Welcome to the source code for Luvit 2.0.  This repo contains the luvit/luvit metapackage and all luvit/* packages as published to [lit][].


### PR DESCRIPTION
Continuation of https://github.com/luvit/luvit/pull/1138, this badge was just missed