### PR TITLE
Fix test-tls-server-verify by removing -tls1 arg

### DIFF
--- a/tests/test-tls-server-verify.lua
+++ b/tests/test-tls-server-verify.lua
@@ -49,7 +49,7 @@ local function optionsIterator(options)
 end
 
 local function runClient(options, port, callback)
-  local args = { 's_client', '-tls1', '-connect', '127.0.0.1:' .. port }
+  local args = { 's_client', '-connect', '127.0.0.1:' .. port }
   print('  connecting with ' .. options.name)
 
   if options.name == 'agent1' then


### PR DESCRIPTION
The node test never had this as far as I can tell, and it seems to be causing problems with recent openssl versions. The error this was causing (#1037, https://github.com/luvit/luvit/pull/1142#issuecomment-868877086) was also being caused retroactively--even running this test with older luvit versions would cause the test to fail even though it used to pass (the test it kinda weird since it calls the system installed openssl binary)

Node test for reference: https://github.com/nodejs/node/blob/f4d0a6a07bf72c556c5ba8e98b3b23327c273e80/test/parallel/test-tls-server-verify.js#L144

Closes #1037