### PR TITLE
test-dns: Quick fix for resolveTxt test on Linux

### DIFF
--- a/tests/test-dns.lua
+++ b/tests/test-dns.lua
@@ -82,8 +82,12 @@ require('tap')(function (test)
     end))
   end)
   test("resolveTxt", function (expect)
+    -- for some reason this test was failing on linux using the system resolver, so
+    -- use the defined default servers instead (the servers will change on the
+    -- next test anyway so this only affects this test)
+    dns.setDefaultServers()
     dns.resolveTxt('google.com', expect(function(err, answers)
-      assert(not err)
+      assert(not err, err)
       p(answers)
       assert(#answers > 0)
     end))


### PR DESCRIPTION
Still not totally sure why this test was failing, but this should fix it until we understand more about it.

See #1148