### PR TITLE
Merge pull request #1142, HTTP CODEC

### DIFF
--- a/deps/http-codec.lua
+++ b/deps/http-codec.lua
@@ -111,7 +111,7 @@ local function encoder()
       assert(path and #path > 0, "expected non-empty path")
       head = { item.method .. ' ' .. item.path .. ' HTTP/' .. version .. '\r\n' }
     else
-      local reason = item.reason or STATUS_CODES[item.code]
+      local reason = item.reason or STATUS_CODES[item.code] or "Unknown reason"
       head = { 'HTTP/' .. version .. ' ' .. item.code .. ' ' .. reason .. '\r\n' }
     end
     for i = 1, #item do


### PR DESCRIPTION
Recently, I have been facing a server breaking error which is reason 
```
http-codec.lua:115: attempt to concatenate local 'reason' (a nil value)
```
Which triggers only when there is no reason provided or STATUS_CODES doesn't exist. As there a few documented STATUS CODES but are not present in the http_codec, sending "Unknown Reason" would be better than breaking the whole server process because of one single reason " reason is nil ".

It shouldn't affect the core, however it will prevent breaking the server.