### PR TITLE
Fix querystring module

### DIFF
--- a/deps/querystring.lua
+++ b/deps/querystring.lua
@@ -52,12 +52,12 @@ end
 
 
 local function stringify(tbl, sep, eq)
-  sep = sep or '&'
-  eq = eq or '='
-
   if type(tbl) ~= 'table' then
     return ''
   end
+
+  sep = sep or '&'
+  eq = eq or '='
 
   local fields = {}
   for key, value in pairs(tbl) do

--- a/deps/querystring.lua
+++ b/deps/querystring.lua
@@ -25,81 +25,88 @@ limitations under the License.
   tags = {"luvit", "url", "codec"}
 ]]
 
-local find = string.find
-local gsub = string.gsub
-local char = string.char
-local byte = string.byte
-local format = string.format
-local match = string.match
-local gmatch = string.gmatch
+
+local function hexToChar(hex)
+  return string.char(tonumber(hex, 16))
+end
+
+local function charToHex(character)
+  return string.format('%%%02X', string.byte(character))
+end
+
 
 local function urldecode(str)
-  str = gsub(str, '+', ' ')
-  str = gsub(str, '%%(%x%x)', function(h)
-    return char(tonumber(h, 16))
-  end)
+  if str then
+    str = string.gsub(str, '+', ' ')
+    str = string.gsub(str, '%%(%x%x)', hexToChar)
+  end
   return str
 end
 
 local function urlencode(str)
   if str then
-    str = gsub(str, '[^a-zA-Z0-9*%-%._]', function(c)
-      return format('%%%02X', byte(c))
-    end)
+    str = string.gsub(str, '[^a-zA-Z0-9*%-%._]', charToHex)
   end
   return str
 end
 
-local function stringifyPrimitive(v)
-  return tostring(v)
-end
 
-local function stringify(params, sep, eq)
-  if not sep then sep = '&' end
-  if not eq then eq = '=' end
-  if type(params) == "table" then
-    local fields = {}
-    for key,value in pairs(params) do
-      local keyString = urlencode(stringifyPrimitive(key)) .. eq
-      if type(value) == "table" then
-        for _, v in ipairs(value) do
-          table.insert(fields, keyString .. urlencode(stringifyPrimitive(v)))
-        end
-      else
-        table.insert(fields, keyString .. urlencode(stringifyPrimitive(value)))
-      end
-    end
-    return table.concat(fields, sep)
+local function stringify(tbl, sep, eq)
+  sep = sep or '&'
+  eq = eq or '='
+
+  if type(tbl) ~= 'table' then
+    return ''
   end
-  return ''
+
+  local fields = {}
+  for key, value in pairs(tbl) do
+    local keyString = urlencode(tostring(key)) .. eq
+
+    if type(value) == 'table' then
+      for _, subValue in ipairs(value) do
+        table.insert(fields, keyString .. urlencode(tostring(subValue)))
+      end
+    else
+      table.insert(fields, keyString .. urlencode(tostring(value)))
+    end
+  end
+
+  return table.concat(fields, sep)
 end
 
--- parse querystring into table. urldecode tokens
 local function parse(str, sep, eq)
-  if not sep then sep = '&' end
-  if not eq then eq = '=' end
-  local vars = {}
-  for pair in gmatch(tostring(str), '[^' .. sep .. ']+') do
-    if not find(pair, eq) then
-      vars[urldecode(pair)] = ''
+  sep = sep or '&'
+  eq = eq or '='
+
+  local keyValuePat = '([^' .. eq .. ']*)' .. eq .. '(.*)'
+
+  local parsed = {}
+  for pair in string.gmatch(tostring(str), '[^' .. sep .. ']+') do
+    if not string.find(pair, eq) then
+      parsed[urldecode(pair)] = ''
     else
-      local key, value = match(pair, '([^' .. eq .. ']*)' .. eq .. '(.*)')
+      local key, value = string.match(pair, keyValuePat)
+
       if key then
         key = urldecode(key)
         value = urldecode(value)
-        local type = type(vars[key])
-        if type=='nil' then
-          vars[key] = value
-        elseif type=='table' then
-          table.insert(vars[key], value)
+
+        local existingValue = parsed[key]
+        if existingValue == nil then
+          parsed[key] = value
+        elseif type(existingValue) == 'table' then
+          table.insert(existingValue, value)
         else
-          vars[key] = {vars[key],value}
+          parsed[key] = {existingValue, value}
         end
       end
     end
   end
-  return vars
+
+  return parsed
 end
+
 
 return {
   urldecode = urldecode,

--- a/deps/querystring.lua
+++ b/deps/querystring.lua
@@ -38,14 +38,12 @@ local function urldecode(str)
   str = gsub(str, '%%(%x%x)', function(h)
     return char(tonumber(h, 16))
   end)
-  str = gsub(str, '\r\n', '\n')
   return str
 end
 
 local function urlencode(str)
   if str then
-    str = gsub(str, '\n', '\r\n')
-    str = gsub(str, '([^%w-_.~])', function(c)
+    str = gsub(str, '[^a-zA-Z0-9*%-%._]', function(c)
       return format('%%%02X', byte(c))
     end)
   end

--- a/deps/querystring.lua
+++ b/deps/querystring.lua
@@ -25,27 +25,37 @@ limitations under the License.
   tags = {"luvit", "url", "codec"}
 ]]
 
+local format = string.format
+local byte = string.byte
+local char = string.char
+local gsub = string.gsub
+local gmatch = string.gmatch
+local find = string.find
+local match = string.match
+local insert = table.insert
+local concat = table.concat
+
 
 local function hexToChar(hex)
-  return string.char(tonumber(hex, 16))
+  return char(tonumber(hex, 16))
 end
 
 local function charToHex(character)
-  return string.format('%%%02X', string.byte(character))
+  return format('%%%02X', byte(character))
 end
 
 
 local function urldecode(str)
   if str then
-    str = string.gsub(str, '+', ' ')
-    str = string.gsub(str, '%%(%x%x)', hexToChar)
+    str = gsub(str, '+', ' ')
+    str = gsub(str, '%%(%x%x)', hexToChar)
   end
   return str
 end
 
 local function urlencode(str)
   if str then
-    str = string.gsub(str, '[^a-zA-Z0-9*%-%._]', charToHex)
+    str = gsub(str, '[^a-zA-Z0-9*%-%._]', charToHex)
   end
   return str
 end
@@ -65,14 +75,14 @@ local function stringify(tbl, sep, eq)
 
     if type(value) == 'table' then
       for _, subValue in ipairs(value) do
-        table.insert(fields, keyString .. urlencode(tostring(subValue)))
+        insert(fields, keyString .. urlencode(tostring(subValue)))
       end
     else
-      table.insert(fields, keyString .. urlencode(tostring(value)))
+      insert(fields, keyString .. urlencode(tostring(value)))
     end
   end
 
-  return table.concat(fields, sep)
+  return concat(fields, sep)
 end
 
 local function parse(str, sep, eq)
@@ -82,11 +92,11 @@ local function parse(str, sep, eq)
   local keyValuePat = '([^' .. eq .. ']*)' .. eq .. '(.*)'
 
   local parsed = {}
-  for pair in string.gmatch(tostring(str), '[^' .. sep .. ']+') do
-    if not string.find(pair, eq) then
+  for pair in gmatch(tostring(str), '[^' .. sep .. ']+') do
+    if not find(pair, eq) then
       parsed[urldecode(pair)] = ''
     else
-      local key, value = string.match(pair, keyValuePat)
+      local key, value = match(pair, keyValuePat)
 
       if key then
         key = urldecode(key)
@@ -96,7 +106,7 @@ local function parse(str, sep, eq)
         if existingValue == nil then
           parsed[key] = value
         elseif type(existingValue) == 'table' then
-          table.insert(existingValue, value)
+          insert(existingValue, value)
         else
           parsed[key] = {existingValue, value}
         end

--- a/tests/test-querystring.lua
+++ b/tests/test-querystring.lua
@@ -2,39 +2,85 @@ local qs = require('querystring')
 local deepEqual = require('deep-equal')
 
 require('tap')(function(test)
-  -- Basic code coverage
-  -- format: { arbitraryQS, canonicalQS, parsedQS, sep, eq }
+  -- Format: { { canonicalQS }, { arbitraryQS }, parsed, sep = sep, eq = eq }
   local tests = {
-    {'foo=1&bar=2', 'foo=1&bar=2', {['foo'] = '1', ['bar'] = '2'}},
-    {'%25 %20+=foo%25%00%41bar&a=%26%3db', '%25%20%20%20=foo%25%00Abar&a=%26%3Db', {['%   '] = 'foo%\000Abar', a = '&=b'}},
-    {'%25 %20+=foo%25%00%41bar&a=%26%3db', '=foo%25%00Abar%26a%3D%26%3Db+%25%20%20=', {['%  '] = '', ['']='foo%\000Abar&a=&=b'}, '+'},
-    {'f', 'f=', {f=''}},
-    {'f>u+u>f', 'f>u+u>f', {u='f', f='u'}, '+', '>'},
+    {
+      { 'foo=1&bar=2', 'bar=2&foo=1' },
+      {},
+      { ['foo'] = '1', ['bar'] = '2' },
+    },
+    {
+      { 'foo=1&foo=2' },
+      {},
+      { ['foo'] = { '1', '2' } },
+    },
+    {
+      { 'a%20=%20%60%7E%21%40%23%24%25%5E%26*%28%29-_%3D%2B%5B%5D%5C%7B%7D%7C%3B%3A%27%22%2C.%2F%3C%3E%3F%0A%0D%0A%00%7F' },
+      {},
+      { ['a '] = ' `~!@#$%^&*()-_=+[]\\{}|;:\'",./<>?\n\r\n\000\127' }
+    },
+    {
+      { 'f=' },
+      { 'f' },
+      { ['f'] = '' },
+    },
+    {
+      { '%25%25s%251G=' },
+      { '%25%s%1G' },
+      { ['%%s%1G'] = '' },
+    },
+    {
+      { 'f>u+u>f', 'u>f+f>u' },
+      {},
+      { u = 'f', f = 'u' },
+      sep = '+', eq = '>',
+    },
   }
 
   test('parse', function(expect)
-    for num, test in ipairs(tests) do
-      local input = test[1]
-      local output = test[3]
-      local tokens = qs.parse(input, test[4], test[5])
-      if not deepEqual(output, tokens) then
+    local function testParse(num, input, output, sep, eq)
+      local parsed = qs.parse(input, sep, eq)
+      if not deepEqual(output, parsed) then
         p("Expected", output)
-        p("But got", tokens)
-        error("Test failed: " .. input)
+        p("But got", parsed)
+        error("Test #" .. num .. " failed: " .. input)
+      end
+    end
+
+    for num, testCase in ipairs(tests) do
+      local canonicalInputs = testCase[1]
+      local arbitraryInputs = testCase[2]
+      local output = testCase[3]
+
+      for _, input in ipairs(canonicalInputs) do
+        testParse(num, input, output, testCase.sep, testCase.eq)
+      end
+
+      for _, input in ipairs(arbitraryInputs) do
+        testParse(num, input, output, testCase.sep, testCase.eq)
       end
     end
   end)
 
   test('stringify', function(expect)
-    for num, test in ipairs(tests) do
-      local input = test[3]
-      local str = qs.stringify(input, test[4], test[5])
-      -- instead of comparing strings, parse the stringified string and compare tables since
-      -- the order of the keys in the stringified string is not deterministic
-      local reparsed = qs.parse(str, test[4], test[5])
-      if not deepEqual(input, reparsed) then
-        p("Expected", input)
-        p("But got", reparsed, "from stringified", str)
+    for num, testCase in ipairs(tests) do
+      local input = testCase[3]
+      local outputs = testCase[1]
+      local stringified = qs.stringify(input, testCase.sep, testCase.eq)
+
+      -- Since the order of the keys in the stringified string is not
+      -- deterministic, we must test all the possibilities
+      local foundValid = false
+      for _, output in ipairs(outputs) do
+        if stringified == output then
+          foundValid = true
+          break
+        end
+      end
+
+      if not foundValid then
+        p("Expected one of", outputs)
+        p("But got", stringified)
         error("Test #" .. num .. " failed")
       end
     end


### PR DESCRIPTION
Currently, the `querystring` module has several issues. Besides neither mirroring Node.js nor adhering to any specification when encoding/decoding strings*, the module's behaviour is definitely not correct as it does not encode spaces at all and breaks CRLF newlines. This PR fixes these issues and cleans up the module's source to match the style used in other modules.

\* I discussed this with @Bilal2453 and @truemedian; we concluded that both `querystring` and `url` could use a re-write, but that's out of this PR's scope.