### PR TITLE
thread: fix thread.equals

### DIFF
--- a/deps/thread.lua
+++ b/deps/thread.lua
@@ -19,7 +19,7 @@ limitations under the License.
 --- luvit thread management
 --[[lit-meta
   name = "luvit/thread"
-  version = "2.1.0"
+  version = "2.1.1"
   license = "Apache 2"
   homepage = "https://github.com/luvit/luvit/blob/master/deps/thread.lua"
   description = "thread module for luvit"
@@ -67,7 +67,7 @@ local function join(thread)
 end
 
 local function equals(thread1,thread2)
-    return uv.thread_equals(thread1,thread2)
+    return uv.thread_equal(thread1,thread2)
 end
 
 local function self()


### PR DESCRIPTION
Luv exposes the libuv method under the name [uv.thread_equal](https://github.com/luvit/luv/blob/master/src/thread.c#L400).
While thread.equals tries to index a non-existence method.