### PR TITLE
Run completion in repl in coroutine

### DIFF
--- a/deps/readline.lua
+++ b/deps/readline.lua
@@ -483,7 +483,9 @@ function Editor:readLine(prompt, callback)
   self.historyIndex = #self.history
 
   self.stdin:set_mode(1)
-  self.stdin:read_start(onKey)
+  self.stdin:read_start(function (...)
+    return coroutine.wrap(onKey)(...)
+  end)
 
 end
 Editor.__index = Editor


### PR DESCRIPTION
I was testing an object that has metamethods for `__pairs` that get triggered when I use autocomplete in the repl.  But my data fetcher needs to be run in a coroutine context.  This PR fixes that.  We have coroutine everywhere else, but missed it the key handler.
