### PR TITLE
Replace code deprecated in Lua 5.1 and 5.2

### DIFF
--- a/deps/childprocess.lua
+++ b/deps/childprocess.lua
@@ -201,9 +201,9 @@ local function _exec(file, args, options, callback)
     maxBuffer = 4 * 1024,
     signal = 'SIGTERM'
   }
-  table.foreach(opts, function(k, v)
+  for k, v in pairs(opts) do
     if not options[k] then options[k] = v end
-  end)
+  end
 
   local child = spawn(file, args, options)
 

--- a/deps/codec.lua
+++ b/deps/codec.lua
@@ -29,6 +29,7 @@ limitations under the License.
 
 local uv = require('uv')
 local assertResume = require('utils').assertResume
+local unpack = unpack or table.unpack ---@diagnostic disable-line: deprecated
 
 local function wrapEmitter(emitter)
   local read, write

--- a/deps/helpful.lua
+++ b/deps/helpful.lua
@@ -25,6 +25,8 @@ limitations under the License.
   tags = {"levenshtein", "string"}
 ]]
 
+local unpack = unpack or table.unpack ---@diagnostic disable-line: deprecated
+
 function string.levenshtein(str1, str2)
 
   -- cost is 0 for equal strings

--- a/deps/http-codec.lua
+++ b/deps/http-codec.lua
@@ -115,7 +115,7 @@ local function encoder()
       head = { 'HTTP/' .. version .. ' ' .. item.code .. ' ' .. reason .. '\r\n' }
     end
     for i = 1, #item do
-      local key, value = unpack(item[i])
+      local key, value = item[i][1], item[i][2]
       local lowerKey = lower(key)
       if lowerKey == "transfer-encoding" then
         chunkedEncoding = lower(value) == "chunked"

--- a/deps/http-header.lua
+++ b/deps/http-header.lua
@@ -34,7 +34,7 @@ local headerMeta = {
     end
     name = name:lower()
     for i = 1, #list do
-      local key, value = unpack(list[i])
+      local key, value = list[i][1], list[i][2]
       if key:lower() == name then return value end
     end
   end,

--- a/deps/http.lua
+++ b/deps/http.lua
@@ -113,7 +113,7 @@ function ServerResponse:flushHeaders()
   local head = {}
   local sent_date, sent_connection, sent_transfer_encoding, sent_content_length
   for i = 1, #headers do
-    local key, value = unpack(headers[i])
+    local key, value = headers[i][1], headers[i][2]
     local klower = key:lower()
     head[#head + 1] = {tostring(key), tostring(value)}
     if klower == "connection" then
@@ -314,7 +314,7 @@ function ClientRequest:initialize(options, callback)
   local host_found, connection_found, user_agent
   for i = 1, #headers do
     self[#self + 1] = headers[i]
-    local key, value = unpack(headers[i])
+    local key, value = headers[i][1], headers[i][2]
     local klower = key:lower()
     if klower == 'host' then host_found = value end
     if klower == 'connection' then connection_found = value end

--- a/deps/readline.lua
+++ b/deps/readline.lua
@@ -40,6 +40,7 @@ local remove = table.remove
 local insert = table.insert
 local concat = table.concat
 local tostring = tostring
+local unpack = unpack or table.unpack ---@diagnostic disable-line: deprecated
 
 local History = {}
 function History:add(line)

--- a/deps/repl.lua
+++ b/deps/repl.lua
@@ -200,11 +200,11 @@ return function (stdin, stdout, greeting)
     -- Namespace builtin libs to make the repl easier to play with
     -- Requires with filenames with a - in them will be camelcased
     -- e.g. pretty-print -> prettyPrint
-    table.foreach(_builtinLibs, function(_, lib)
+    for _, lib in pairs(_builtinLibs) do
       local requireName = lib:gsub('-.', function (char) return char:sub(2):upper() end)
       local req = string.format('%s = require("%s")', requireName, lib)
       evaluateLine(req)
-    end)
+    end
   end
 
   return {

--- a/deps/repl.lua
+++ b/deps/repl.lua
@@ -84,15 +84,14 @@ return function (stdin, stdout, greeting)
       return '> '
     end
     local chunk  = buffer .. line
-    local f, err = loadstring('return ' .. chunk, 'REPL') -- first we prefix return
+    local f, err = load('return ' .. chunk, 'REPL', nil, global) -- first we prefix return
 
     if not f then
-      f, err = loadstring(chunk, 'REPL') -- try again without return
+      f, err = load(chunk, 'REPL', nil, global) -- try again without return
     end
 
 
     if f then
-      setfenv(f, global)
       buffer = ''
       local success, results = gatherResults(xpcall(f, debug.traceback))
 
@@ -134,9 +133,8 @@ return function (stdin, stdout, greeting)
     if prefix and prefix ~= rest then return end
     local scope
     if base then
-      local f = loadstring("return " .. base)
+      local f = load("return " .. base, nil, nil, global)
       if not f then return {} end
-      setfenv(f, global)
       local ok
       ok, scope = pcall(f)
       if not ok then return {} end

--- a/deps/require.lua
+++ b/deps/require.lua
@@ -114,7 +114,7 @@ local function statFile(path)
     statCache[path] = stat
     return stat
   end
-  return nil, err or "Problem statting: " .. path
+  return nil, err or ("Problem statting: " .. path)
 end
 
 
@@ -298,15 +298,14 @@ function Module:require(name)
     else
       path = "@" .. path
     end
-    local fn = assert(loadstring(data, path))
-    local global = {
+    local global = setmetatable({
       module = module,
       exports = module.exports,
       require = function (...)
         return module:require(...)
       end
-    }
-    setfenv(fn, setmetatable(global, { __index = _G }))
+    }, { __index = _G })
+    local fn = assert(load(data, path, nil, global))
     local ret = fn()
 
     -- Allow returning the exports as well

--- a/deps/stream/stream_readable.lua
+++ b/deps/stream/stream_readable.lua
@@ -113,7 +113,7 @@ function len(buf)
   if type(buf) == 'string' then
     return string.len(buf)
   elseif type(buf) == 'table' then
-    return table.getn(buf)
+    return #buf
   else
     return -1
   end

--- a/deps/stream/stream_writable.lua
+++ b/deps/stream/stream_writable.lua
@@ -248,7 +248,7 @@ function Writable:uncork()
         state.corked == 0 and
         not state.finished and
         not state.bufferProcessing and
-        table.getn(state.buffer) ~= 0 then
+        #state.buffer ~= 0 then
       clearBuffer(self, state)
     end
   end
@@ -356,7 +356,7 @@ function onwrite(stream, er)
     if not finished and
         state.corked == 0 and
         not state.bufferProcessing and
-        table.getn(state.buffer) ~= 0 then
+        #state.buffer ~= 0 then
       clearBuffer(stream, state)
     end
 
@@ -398,12 +398,12 @@ end
 function clearBuffer(stream, state)
   state.bufferProcessing = true
 
-  if stream._writev and table.getn(state.buffer) > 1 then
+  if stream._writev and #state.buffer > 1 then
     --[[
     // Fast case, write everything using _writev()
     --]]
     local cbs = {}
-    for c = 1,table.getn(state.buffer) do
+    for c = 1, #state.buffer do
       table.insert(cbs, state.buffer[c].callback)
     end
 
@@ -413,7 +413,7 @@ function clearBuffer(stream, state)
     --]]
     state.pendingcb = state.pendingcb + 1
     doWrite(stream, state, true, state.length, state.buffer, function(err)
-      for i = 1,table.getn(cbs) do
+      for i = 1, #cbs do
         state.pendingcb = state.pendingcb - 1
         cbs[i](err)
       end
@@ -428,7 +428,7 @@ function clearBuffer(stream, state)
     // Slow case, write chunks one-by-one
     --]]
     local c = 1
-    while c <= table.getn(state.buffer) do
+    while c <= #state.buffer do
       local entry = state.buffer[c]
       local chunk = entry.chunk
       local cb = entry.callback
@@ -454,7 +454,7 @@ function clearBuffer(stream, state)
       c = c + 1
     end
 
-    if c <= table.getn(state.buffer) then
+    if c <= #state.buffer then
       -- node.js: state.buffer = state.buffer.slice(c)
       for i=1,c-1 do
         table.remove(state.buffer, 1)
@@ -503,7 +503,7 @@ end
 
 
 function needFinish(stream, state)
-  return state.ending and state.length == 0 and table.getn(state.buffer) == 0 and
+  return state.ending and state.length == 0 and #state.buffer == 0 and
   not state.finished and not state.writing
 end
 

--- a/deps/thread.lua
+++ b/deps/thread.lua
@@ -51,9 +51,11 @@ local function start(thread_func, ...)
     -- Inject the global process table
     _G.process = mainRequire('process').globalProcess()
 
-    -- Run function with require injected
-    local fn = loadstring(dumped)
-    getfenv(fn).require = mainRequire
+    -- Inject require
+    _G.require = mainRequire
+
+    -- Run function
+    local fn = load(dumped)
     fn(...)
 
     -- Start new event loop for thread.
@@ -95,7 +97,7 @@ local function work(thread_func, notify_entry)
     --try to find cached function entry
     local fn
     if not _G._uv_works[dumped] then
-      fn = loadstring(dumped)
+      fn = load(dumped)
 
       -- Convert paths back to table
       local paths = {}
@@ -110,7 +112,7 @@ local function work(thread_func, notify_entry)
       _G.process = _G.process or mainRequire('process').globalProcess()
 
       -- require injected
-      getfenv(fn).require = mainRequire
+      _G.require = mainRequire
 
       -- cache it
       _G._uv_works[dumped] = fn

--- a/deps/timer.lua
+++ b/deps/timer.lua
@@ -32,6 +32,7 @@ local uv = require('uv')
 local Object = require('core').Object
 local bind = require('utils').bind
 local assertResume = require('utils').assertResume
+local unpack = unpack or table.unpack ---@diagnostic disable-line: deprecated
 
 -------------------------------------------------------------------------------
 

--- a/deps/tls/common.lua
+++ b/deps/tls/common.lua
@@ -24,6 +24,7 @@ local timer = require('timer')
 local resource = require('resource')
 local uv = require('uv')
 local utils = require('utils')
+local unpack = unpack or table.unpack ---@diagnostic disable-line: deprecated
 
 local createCredentials
 local DEFAULT_CIPHERS

--- a/deps/utils.lua
+++ b/deps/utils.lua
@@ -28,6 +28,7 @@ limitations under the License.
   tags = {"luvit", "bind", "adapter"}
 ]]
 
+local unpack = unpack or table.unpack ---@diagnostic disable-line: deprecated
 local Error = require('core').Error
 local utils = {}
 local pp = require('pretty-print')

--- a/examples/stream/libs/wait.lua
+++ b/examples/stream/libs/wait.lua
@@ -2,6 +2,7 @@
 local coroutine = require('coroutine')
 local debug = require 'debug'
 local fiber = {}
+local unpack = unpack or table.unpack ---@diagnostic disable-line: deprecated
 
 function fiber.new(block) return function (callback)
   local paused

--- a/init.lua
+++ b/init.lua
@@ -16,6 +16,7 @@ limitations under the License.
 
 --]]
 local uv = require('uv')
+local unpack = unpack or table.unpack ---@diagnostic disable-line: deprecated
 
 return function (main, ...)
   -- Inject the global process table


### PR DESCRIPTION
Towards making Luvit less dependent on Lua versioning, I've replaced some code that is deprecated in earlier versions of Lua.

### Lua 5.1

> Function `table.setn` was deprecated. Function `table.getn` corresponds to the new length operator (`#`); use the operator instead of the function.

I replaced `table.getn` calls with `#`. Luvit doesn't use `table.setn`.

> Functions `table.foreach` and `table.foreachi` are deprecated. You can use a for loop with `pairs` or `ipairs` instead. 

I replaced `table.foreach` with `pairs` loops. Luvit doesn't use `table.foreachi`.

### Lua 5.2
> Function `unpack` was moved into the table library and therefore must be called as `table.unpack`.

Both `unpack` and `table.unpack` exist in LuaJIT with `DLUAJIT_ENABLE_LUA52COMPAT`, but `table.unpack` does not exist in stock LuaJIT and `unpack` does not exist in Lua 5.3+. I converted `unpack` calls to indexings where possible or added conditional `unpack` definitions elsewhere.

> Function `loadstring` is deprecated. Use `load` instead; it now accepts string arguments and are exactly equivalent to `loadstring`.

Both `loadstring` and `load` exist in stock LuaJIT and have the same 5.2 behavior; `loadstring` does not exist in 5.3+. I replaced all `loadstring` calls with `load` calls.

> Functions `setfenv` and `getfenv` were removed, because of the changes in environments.

All calls to `setfenv` are on loaded functions, so I just moved the environment tables into the `load` calls. All calls to `getfenv` are used to define `require` in thread callbacks, which have their own global environment, so I changed those to simple assignments and it seems to work the same.