### PR TITLE
buffer: make sure memory is zeroed out

### DIFF
--- a/deps/buffer.lua
+++ b/deps/buffer.lua
@@ -34,7 +34,7 @@ local Object = core.Object
 local instanceof = core.instanceof
 
 ffi.cdef[[
-  void *malloc (size_t __size);
+  void *calloc (size_t nmemb, size_t __size);
   void free (void *__ptr);
 ]]
 
@@ -49,11 +49,11 @@ local C = ffi.os == "Windows" and ffi.load("msvcrt") or ffi.C
 function Buffer:initialize(length)
   if type(length) == "number" then
     self.length = length
-    self.ctype = ffi.gc(ffi.cast("unsigned char*", C.malloc(length)), C.free)
+    self.ctype = ffi.gc(ffi.cast("unsigned char*", C.calloc(1, length)), C.free)
   elseif type(length) == "string" then
     local string = length
     self.length = #string
-    self.ctype = ffi.gc(ffi.cast("unsigned char*", C.malloc(self.length)), C.free)
+    self.ctype = ffi.gc(ffi.cast("unsigned char*", C.calloc(1, self.length)), C.free)
     ffi.copy(self.ctype, string, self.length)
   else
     error("Input must be a string or number")

--- a/deps/buffer.lua
+++ b/deps/buffer.lua
@@ -49,11 +49,11 @@ local C = ffi.os == "Windows" and ffi.load("msvcrt") or ffi.C
 function Buffer:initialize(length)
   if type(length) == "number" then
     self.length = length
-    self.ctype = ffi.gc(ffi.cast("unsigned char*", C.calloc(1, length)), C.free)
+    self.ctype = ffi.gc(ffi.cast("unsigned char*", C.calloc(length, 1)), C.free)
   elseif type(length) == "string" then
     local string = length
     self.length = #string
-    self.ctype = ffi.gc(ffi.cast("unsigned char*", C.calloc(1, self.length)), C.free)
+    self.ctype = ffi.gc(ffi.cast("unsigned char*", C.calloc(self.length, 1)), C.free)
     ffi.copy(self.ctype, string, self.length)
   else
     error("Input must be a string or number")

--- a/deps/buffer.lua
+++ b/deps/buffer.lua
@@ -17,7 +17,7 @@ limitations under the License.
 --]]
 --[[lit-meta
   name = "luvit/buffer"
-  version = "2.1.0"
+  version = "2.1.1"
   dependencies = {
     "luvit/core@2.0.0"
   }

--- a/deps/buffer.lua
+++ b/deps/buffer.lua
@@ -34,6 +34,7 @@ local Object = core.Object
 local instanceof = core.instanceof
 
 ffi.cdef[[
+  void *malloc (size_t __size);
   void *calloc (size_t nmemb, size_t __size);
   void free (void *__ptr);
 ]]
@@ -53,7 +54,7 @@ function Buffer:initialize(length)
   elseif type(length) == "string" then
     local string = length
     self.length = #string
-    self.ctype = ffi.gc(ffi.cast("unsigned char*", C.calloc(self.length, 1)), C.free)
+    self.ctype = ffi.gc(ffi.cast("unsigned char*", C.malloc(self.length)), C.free)
     ffi.copy(self.ctype, string, self.length)
   else
     error("Input must be a string or number")


### PR DESCRIPTION
As I just noticed while reviewing my [luvit-meta](https://github.com/Bilal2453/luvit-meta) definitions of the Buffer class, doing the following:

```lua
local buf = buffer.Buffer:new(16)
print(buf:inspect())
```
will print a string with random contents, I first thought `malloc` did zero-out the memory it allocates but apparently not.

Thanks for @truemedian to point that out + telling me to use `calloc` instead of `memset` as this is apparently faster than doing another call to `memset`, this should "fix" it.  "Fix it" assuming it wasn't an intended behavior.