### PR TITLE
buffer: ensure memory safety on toString

### DIFF
--- a/deps/buffer.lua
+++ b/deps/buffer.lua
@@ -17,7 +17,7 @@ limitations under the License.
 --]]
 --[[lit-meta
   name = "luvit/buffer"
-  version = "2.1.1"
+  version = "2.1.2"
   dependencies = {
     "luvit/core@2.0.0"
   }
@@ -200,6 +200,7 @@ Buffer.writeInt32BE = Buffer.writeUInt32BE
 
 function Buffer:toString(i, j)
   local offset = i and i - 1 or 0
+  if (offset < 0 or offset > self.length) or (j and j > self.length) then error("Range out of bounds") end
   return ffi.string(self.ctype + offset, (j or self.length) - offset)
 end
 


### PR DESCRIPTION
Currently, any values are allowed to be passed as arguments to `Buffer.toString`, effectively allowing out of bound access.   Usually this would just lead to reading random bytes / zeros, but it can also result into a segfault; for example on my machine this segfaults:

```lua
local buf = Buffer:new(4)
buf:toString(1, 2^30) 
```

While I admit the value is very unlikely to be an input (and is pretty much nonsensical), but in theory any out of bound access can result in this segfault making debugging the code much harder.

This ensures that won't happen by checking for the input range, I think this is the right thing to do since `__index` and `__newindex` all do it too so feels a bit weird for this to not have it as well.

The range I allow here is: `i = (0, self.length + 1]`, `j = (-inf, self.length)`.  Effectively this makes the following calls possible:
```lua
local buf = Buffer:new(4)
buf:toString(1, 4) -- reads 4 bytes
buf:toString(4, 4) -- reads the last byte
buf:toString(5, 4)  -- reads 0 bytes
buf:toString(3, 2)  -- reads 0 bytes
buf:toString(3, 1)  -- errors on ffi.string side, so we allow it here
buf:toString(1, -100) -- errors on ffi.string side
```
and any calls that make the offset read outside of the pointer we have are disallowed:
```lua
buf:toString(0, 3) -- errors: as `i - 1` will set the offset behind the data 
buf:toString(4, 5)  -- errors: trying to read outside the buffer memory
buf:toString(2, -1) -- errors on ffi.string side
```

I wrote those checks at 2AM though so maybe I missed something there.