### PR TITLE
Removed unnecessary `tostring` call

### DIFF
--- a/deps/ustring.lua
+++ b/deps/ustring.lua
@@ -230,7 +230,7 @@ function _meta.__eq(ustr1,ustr2)
 end
 
 function _meta.__tostring(self)
-    return tostring(table.concat(self))
+    return table.concat(self)
 end
 
 function _meta.__concat(ustr1,ustr2)


### PR DESCRIPTION
`table.concat` is guaranteed to return a string according to Lua docs.

Unless the `tostring` call is there to simulate behavior of global tostring function being replaced, which I assume is not the reason