### PR TITLE
feat: buffer: add a __len metamethod

### DIFF
--- a/deps/buffer.lua
+++ b/deps/buffer.lua
@@ -71,6 +71,10 @@ function Buffer.meta:__ipairs()
   end
 end
 
+function Buffer.meta:__len()
+  return self.length
+end
+
 function Buffer.meta:__tostring()
   return ffi.string(self.ctype, self.length)
 end


### PR DESCRIPTION
It would make sense that one would be able to do `#buffer` to get the length, and since we are already adding __ipairs, __tostring and __concat, can't see why not this too.