### PR TITLE
remove or indicate all mandatory luajit dependencies from luvit

### DIFF
--- a/deps/buffer.lua
+++ b/deps/buffer.lua
@@ -27,6 +27,10 @@ limitations under the License.
   tags = {"luvit", "buffer"}
 ]]
 
+if not pcall(require, 'ffi') then
+  error("The 'buffer' module requires FFI support, which is not available on this platform.")
+end
+
 local core = require('core')
 local ffi = require('ffi')
 

--- a/deps/buffer.lua
+++ b/deps/buffer.lua
@@ -17,7 +17,7 @@ limitations under the License.
 --]]
 --[[lit-meta
   name = "luvit/buffer"
-  version = "2.1.2"
+  version = "2.1.3"
   dependencies = {
     "luvit/core@2.0.0"
   }

--- a/deps/dns.lua
+++ b/deps/dns.lua
@@ -36,9 +36,6 @@ limitations under the License.
   tags = {"luvit", "dns"}
 ]]
 
-if not pcall(require, 'ffi') then
-  error("The 'dns' module requires FFI support, which is not available on this platform.")
-end
 
 local dgram = require('dgram')
 local fs = require('fs')
@@ -46,7 +43,8 @@ local net = require('net')
 local timer = require('timer')
 local Error = require('core').Error
 local adapt = require('utils').adapt
-local ffi = require('ffi')
+local los = require('los')
+local has_ffi, ffi = pcall(require, 'ffi')
 
 local bit = require('bit')
 local crypto = require('tls/lcrypto')
@@ -67,7 +65,11 @@ local ipapi
 
 if _G._luvit_dns_load then
   ipapi = _G._luvit_dns_load
-elseif ffi.os=='Windows' then
+elseif los.type() == 'win32' then
+  if not has_ffi then
+    error("The 'dns' module requires FFI support on Windows, which is not available on this platform.")
+  end
+
   ffi.cdef[[
     typedef uint32_t DWORD; //Integer
     typedef uint32_t ULONG; //Alias
@@ -824,6 +826,8 @@ local function setDefaultServers()
 end
 
 local function loadResolverWin(options)
+  assert(ffi, 'ffi not available on this platform')
+
   local servers = {}
 
   local pOutBufLen = ffi.new("ULONG[1]")
@@ -905,7 +909,7 @@ local function loadResolverUnix(options)
 end
 
 local function loadResolver(options)
-  if ffi.os=='Windows' then
+  if los.type() == 'win32' then
     return loadResolverWin(options)
   else
     return loadResolverUnix(options)

--- a/deps/dns.lua
+++ b/deps/dns.lua
@@ -36,6 +36,10 @@ limitations under the License.
   tags = {"luvit", "dns"}
 ]]
 
+if not pcall(require, 'ffi') then
+  error("The 'dns' module requires FFI support, which is not available on this platform.")
+end
+
 local dgram = require('dgram')
 local fs = require('fs')
 local net = require('net')

--- a/deps/dns.lua
+++ b/deps/dns.lua
@@ -20,7 +20,7 @@ limitations under the License.
 -- https://github.com/openresty/lua-resty-dns/blob/master/lib/resty/dns/resolver.lua
 --[[lit-meta
   name = "luvit/dns"
-  version = "2.0.4"
+  version = "2.0.5"
   dependencies = {
     "luvit/dgram@2.0.0",
     "luvit/fs@2.0.0",
@@ -35,7 +35,6 @@ limitations under the License.
   description = "Node-style dns module for luvit"
   tags = {"luvit", "dns"}
 ]]
-
 
 local dgram = require('dgram')
 local fs = require('fs')

--- a/deps/los.lua
+++ b/deps/los.lua
@@ -18,7 +18,7 @@ limitations under the License.
 
 --[[lit-meta
   name = "luvit/los"
-  version = "2.0.0"
+  version = "2.0.1"
   license = "Apache 2"
   homepage = "https://github.com/luvit/luvit/blob/master/deps/los.lua"
   description = "Tiny helper to get os name in luvit."

--- a/deps/pathjoin.lua
+++ b/deps/pathjoin.lua
@@ -9,12 +9,7 @@
 
 local getPrefix, splitPath, joinParts
 
-local isWindows
-if _G.jit then
-  isWindows = _G.jit.os == "Windows"
-else
-  isWindows = not not package.path:match("\\")
-end
+local isWindows = require("los").type() == "win32"
 
 if isWindows then
   -- Windows aware path utilities

--- a/deps/require.lua
+++ b/deps/require.lua
@@ -17,7 +17,7 @@ limitations under the License.
 --]]
 --[[lit-meta
   name = "luvit/require"
-  version = "2.2.3"
+  version = "2.2.4"
   homepage = "https://github.com/luvit/luvit/blob/master/deps/require.lua"
   description = "Luvit's custom require system with relative requires and sane search paths."
   tags = {"luvit", "require"}

--- a/deps/require.lua
+++ b/deps/require.lua
@@ -29,14 +29,14 @@ local luvi = require('luvi')
 local bundle = luvi.bundle
 local pathJoin = luvi.path.join
 local env = require('env')
-local os = require('ffi').os
 local uv = require('uv')
 
 local realRequire = _G.require
 
-local tmpBase = os == "Windows" and (env.get("TMP") or uv.cwd()) or
-                                    (env.get("TMPDIR") or '/tmp')
-local binExt = os == "Windows" and ".dll" or ".so"
+local tmpBase = env.get("TMPDIR") or env.get("TMP") or env.get("TEMP") or (uv.fs_access("/tmp", "r") and "/tmp") or uv.cwd()
+
+local first_cpath = package.cpath:match("[^" .. package.config:sub(3, 3) .. "]+")
+local binExt = (first_cpath and first_cpath:match("%.[^.]+$")) or (package.config:sub(1, 1) == "\\" and ".dll" or ".so")
 
 -- Package sources
 -- $author/$name@$version -> resolves to hash, cached in memory

--- a/init.lua
+++ b/init.lua
@@ -37,7 +37,7 @@ return function (main, ...)
 
   -- EPIPE ignore
   do
-    if jit.os ~= 'Windows' then
+    if require("los").type() ~= 'win32' then
       local sig = uv.new_signal()
       uv.signal_start(sig, 'sigpipe')
       uv.unref(sig)

--- a/main.lua
+++ b/main.lua
@@ -135,7 +135,7 @@ return require('./init')(function (...)
     local c = utils.color
     local greeting = "Welcome to the " .. c("err") .. "L" .. c("quotes") .. "uv" .. c("table") .. "it" .. c() .. " repl!"
     local historyFile
-    if require('ffi').os == "Windows" then
+    if require('los').type() == "win32" then
       historyFile = pathJoin(env.get("APPDATA"), "luvit_history")
     else
       historyFile = pathJoin(env.get("HOME"), ".luvit_history")

--- a/tests/test-dns.lua
+++ b/tests/test-dns.lua
@@ -17,7 +17,7 @@ limitations under the License.
 --]]
 
 local dns = require('dns')
-local jit = require('jit')
+local los = require('los')
 local path = require('luvi').path
 
 -- Appveyor is failing builds randomly... need to re-enable
@@ -118,9 +118,7 @@ require('tap')(function (test)
     end))
   end)
   test("load resolver", function ()
-    if jit.os == 'Windows' then
-      return
-    end
+    if los.type() == 'win32' then return end
     local servers = dns.loadResolver({ file = path.join(module.dir, 'fixtures', 'resolve.conf.a')})
     assert(#servers == 3)
     assert(servers[1].host == '192.168.0.1')
@@ -129,7 +127,7 @@ require('tap')(function (test)
     dns.setDefaultServers()
   end)
   test("load resolver (resolv.conf search)", function ()
-    if jit.os == 'Windows' then return end
+    if los.type() == 'win32' then return end
     local servers = dns.loadResolver({ file = path.join(module.dir, 'fixtures', 'resolve.conf.b')})
     assert(#servers == 2)
     assert(servers[1].host == '127.0.0.1')

--- a/tests/test-ffi.lua
+++ b/tests/test-ffi.lua
@@ -16,6 +16,10 @@ limitations under the License.
 
 --]]
 
+if not pcall(require, 'ffi') then
+  return
+end
+
 local ffi = require('ffi')
 local timer = require('timer')
 local los = require('los')


### PR DESCRIPTION
This PR removes the luajit ffi and jit libraries as mandatory dependencies for all but 2 luvit libraries: dns and buffer, both of which use ffi as part of their operation.

The general migration pattern was: anything that used `jit.os` or `ffi.os` now uses the luvit `los` library.

The `los` library now tries to use a few different methods to find the OS, starting with `jit.os` and `ffi.os`. Then it tries to use `uname -s`. Then it tries the `OS` environment variable.

This means `los` will now work in a non-luajit environment, this is not a breaking change.

Migration of `require` was handled differently, because it does not actually depend on any other luvit libraries. To this end: how luvit require chooses a temporary directory has changed, it is now OS-agnostic. The binary extension is now inferred from the first entry of the `package.cpath`, or the path separator present in `package.config` if a cpath entry is not present or does not have a file extension.

Accompanying these changes:

- The version of `luvit/require` has been bumped to `2.2.4`
  - This version no longer has any dependency on luajit
- The version of `luvit/los` has been bumped to `2.0.1``
  - This version no longer has any dependency on luajit
- The version of `luvit/dns` has been bumped to `2.0.5``
  - This version only has a dependency on luajit for Windows
- The version of `luvit/buffer` has been bumped to `2.1.3`
  - This version has a mandatory dependency on luajit, but it now has an informative error.