### PR TITLE
add windows to action, revert macos to non-arm version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,21 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-13, ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build
         run: make luvit
       - name: Test
         run: make test
+
+  build-windows:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: ./make luvit
+      - name: Test
+        run: ./make test


### PR DESCRIPTION
CI is broken now that macos-latest has moved to aarch64, but luvit does not provide aarch64 binaries.