### PR TITLE
fix: pretty-print: DEL not listed in controls

### DIFF
--- a/deps/pretty-print.lua
+++ b/deps/pretty-print.lua
@@ -17,7 +17,7 @@ limitations under the License.
 --]]
 --[[lit-meta
   name = "luvit/pretty-print"
-  version = "2.1.1"
+  version = "2.1.2"
   homepage = "https://github.com/luvit/luvit/blob/master/deps/pretty-print.lua"
   description = "A lua value pretty printer and colorizer for terminals."
   tags = {"colors", "tty"}
@@ -152,13 +152,8 @@ function loadColors(index)
   controls[92] = colorize('escape', '\\\\', 'string')
   controls[34] = colorize('escape', '\\"', 'string')
   controls[39] = colorize('escape', "\\'", 'string')
-  for i = 128, 255 do
-    local c
-    if i < 100 then
-      c = "0" .. tostring(i)
-    else
-      c = tostring(i)
-    end
+  for i = 127, 255 do
+    local c = tostring(i)
     controls[i] = colorize('escape', '\\' .. c, 'string')
   end
 


### PR DESCRIPTION
If you try the following code:
```lua
require('pretty-print').prettyPrint('\127') -- DEL - most often a backspace
```
will print:
![image](https://github.com/user-attachments/assets/e1e338ae-6e1b-46fc-bc0c-b9eddd77ba23)


This happens because in [dump's process](https://github.com/luvit/luvit/blob/master/deps/pretty-print.lua#L238-L246) function: we call [stringEscape](https://github.com/luvit/luvit/blob/master/deps/pretty-print.lua#L178) with the DEL character, which the `string.byte` of that will be `\127`, [then stringEscape will attempt to index](https://github.com/luvit/luvit/blob/master/deps/pretty-print.lua#L178) the `controls` table with that input, but over in [loadColors](https://github.com/luvit/luvit/blob/master/deps/pretty-print.lua#L155-L162) we never actually define anything for `\127`. From my testing seems like `\127` is the only character in the ASCII/Extended ASCII range that we left out.

This Fixes it by extending the [extended ascii loop](https://github.com/luvit/luvit/blob/master/deps/pretty-print.lua#L155)  to also include `127`, the alternative fix would be to have `controls[127] = colorize('escape', '\\' .. tostring(c), 'string')` which is kind of repeating that same for loop logic.

Notice that the if statement inside the loop was removed, as `i` is never below 100. Seems like a copy-paste error from the other similar loops in the code.

This issue was brought to attention by @TohruMKDM.
@truemedian noticed the irrelevant loop.

Note: wanted to add a test case for `dump` covering the entire ascii range, but I ended up replicating the same logic which didn't feel good for a test, my other option was to hardcode the expected values in that range which I didn't feel like doing.