### PR TITLE
fix: remove double usage of .sysname in los

### DIFF
--- a/deps/los.lua
+++ b/deps/los.lua
@@ -48,7 +48,7 @@ local function get_os_name()
 
   -- use libuv provided uname if possible, but it's not always available
   if uv.os_uname then
-    local info = uv.os_uname().sysname
+    local info = uv.os_uname()
     if info then
       return info.sysname
     end


### PR DESCRIPTION
This was causing the function to return `nil` and error below at the `string.lower`. This currently breaks for all non-luajit targets with libuv >= 1.25 (which I assume is all of the non luajit targets).