### PR TITLE
ignore tools from lit releases

### DIFF
--- a/package.lua
+++ b/package.lua
@@ -58,5 +58,6 @@ return {
     "!tests",
     "!bench",
     "!lit-*",
+    "!tools"
   }
 }


### PR DESCRIPTION
The Lit releases include all `.lua` files found in any directory, which seems to me like it would also include ones found in [tools](https://github.com/luvit/luvit/tree/master/tools) hence we have [examples](https://github.com/luvit/luvit/tree/master/examples), [tests](https://github.com/luvit/luvit/tree/master/tests), etc directories explicitly ignored. 

Currently no Luvit releases has this included, check [v2.18.1's tree](https://lit.luvit.io/trees/24bf1841d1252481b4ccc9336466b7c82e40bd9d/luvit/luvit/v2.18.1/), not sure why none of the releases include the tools directory even though it is not excluded, but this PR should make sure that never happens.