### PR TITLE
add a github action for coveralls

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -1,0 +1,36 @@
+name: "Coverage analysis"
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  luacov:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Luvit
+        run: make luvit
+      - name: Setup Lua & Luarocks
+        env:
+          LUA_VER: lua-5.1.5
+          LUAROCKS_VER: luarocks-3.11.1
+        run: |
+          curl https://www.lua.org/ftp/$LUA_VER.tar.gz | tar xz
+          cd $LUA_VER
+          make linux && make install INSTALL_TOP=../install
+          cd ..
+          curl -L https://luarocks.github.io/luarocks/releases/$LUAROCKS_VER.tar.gz | tar xz
+          cd $LUAROCKS_VER
+          ./configure --with-lua=$GITHUB_WORKSPACE/$LUA_VER/install --prefix="./install"
+          make && make install
+          ln ./install/bin/luarocks $GITHUB_WORKSPACE/luarocks
+      - name: Install luacov & luacov-coveralls
+        run: |
+          $GITHUB_WORKSPACE/luarocks install luacov
+          $GITHUB_WORKSPACE/luarocks install luacov-coveralls
+      - name: Run coverage
+        run: |
+          export LUA_PATH=`$GITHUB_WORKSPACE/luarocks path --lr-path`
+          export LUA_CPATH=`$GITHUB_WORKSPACE/luarocks path --lr-cpath`
+          export PATH="$($GITHUB_WORKSPACE/luarocks path --lr-bin):$PATH"
+          make cover
+          luacov-coveralls -c tests/.luacov -t "${{secrets.GITHUB_TOKEN}}"

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -10,27 +10,13 @@ jobs:
       - name: Setup Luvit
         run: make luvit
       - name: Setup Lua & Luarocks
-        env:
-          LUA_VER: lua-5.1.5
-          LUAROCKS_VER: luarocks-3.11.1
         run: |
-          curl https://www.lua.org/ftp/$LUA_VER.tar.gz | tar xz
-          cd $LUA_VER
-          make linux && make install INSTALL_TOP=../install
-          cd ..
-          curl -L https://luarocks.github.io/luarocks/releases/$LUAROCKS_VER.tar.gz | tar xz
-          cd $LUAROCKS_VER
-          ./configure --with-lua=$GITHUB_WORKSPACE/$LUA_VER/install --prefix="./install"
-          make && make install
-          ln ./install/bin/luarocks $GITHUB_WORKSPACE/luarocks
+          sudo apt install luarocks
       - name: Install luacov & luacov-coveralls
         run: |
-          $GITHUB_WORKSPACE/luarocks install luacov
-          $GITHUB_WORKSPACE/luarocks install luacov-coveralls
+          sudo luarocks install luacov
+          sudo luarocks install luacov-coveralls
       - name: Run coverage
         run: |
-          export LUA_PATH=`$GITHUB_WORKSPACE/luarocks path --lr-path`
-          export LUA_CPATH=`$GITHUB_WORKSPACE/luarocks path --lr-cpath`
-          export PATH="$($GITHUB_WORKSPACE/luarocks path --lr-bin):$PATH"
           make cover
           luacov-coveralls -c tests/.luacov -t "${{secrets.GITHUB_TOKEN}}"

--- a/tests/.luacov
+++ b/tests/.luacov
@@ -1,0 +1,5 @@
+return {
+  exclude = {
+    'tests/.+',
+  }
+}


### PR DESCRIPTION
This brings back the luacov-coveralls support as a github action, which was removed with the Travis deprecation in https://github.com/luvit/luvit/pull/1146, further contributing toward https://github.com/luvit/luvit/issues/1141.

Also fixes #1220.

### Code notes

Usually we run the coverage with `make cover`, which is `luvi . -- -l luacov tests/run.lua`, which means luacov needs to be ran from the root tree.  Luacov searches the current working directory for a `.luacov` config file, but we instead have that in `tests/.luacov` (for a cleaner tree), the action will set `tests/.luacov` as the config file with `luacov-coveralls -c tests/.luacov` which seems to be enough.

### Setup notes

This action is triggered on new commits as well as pull requests, it is also possible to manually trigger it with a dispatch.

Note that the Github token is used instead of a Coveralls token, which means you do not have to setup anything, the Github token should be already provided to Actions through `secrets.GITHUB_TOKEN`.  The only thing that might need setup is after merging the PR the root tree prefix in Coveralls might need to be updated to `/home/runnder/work/luvit/luvit/`.