### PR TITLE
adopt creationix/pathjoin, bump resource for new pathjoin

### DIFF
--- a/deps/pathjoin.lua
+++ b/deps/pathjoin.lua
@@ -1,5 +1,5 @@
 --[[lit-meta
-  name = "creationix/pathjoin"
+  name = "luvit/pathjoin"
   description = "The path utilities that used to be part of luvi"
   version = "2.0.0"
   tags = {"path"}

--- a/deps/resource.lua
+++ b/deps/resource.lua
@@ -18,12 +18,12 @@ limitations under the License.
 
 --[[lit-meta
   name = "luvit/resource"
-  version = "2.1.0"
+  version = "2.1.1"
   license = "Apache 2"
   homepage = "https://github.com/luvit/luvit/blob/master/deps/resource.lua"
   description = "Utilities for loading relative resources"
   dependencies = {
-    "creationix/pathjoin@2.0.0"
+    "luvit/pathjoin@2.0.0"
   }
   tags = {"luvit", "relative", "resource"}
 ]]


### PR DESCRIPTION
This was missed during the adoption in the Lit repository but `pathjoin`'s home is here and it was never fixed here. `luvit/resource` was bumped to rely on the new `luvit/pathjoin` instead of `creationix/pathjoin`