### PR TITLE
fix #1019: make sure error objects are strings

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -68,7 +68,7 @@ return function (main, ...)
     uv.run()
   else
     _G.process.exitCode = -1
-    require('pretty-print').stderr:write("Uncaught exception:\n" .. err .. "\n")
+    require('pretty-print').stderr:write("Uncaught exception:\n" .. tostring(err) .. "\n")
   end
 
   local function isFileHandle(handle, name, fd)


### PR DESCRIPTION
See the following comments for context: https://github.com/luvit/luvit/issues/1019#issuecomment-354388815, https://github.com/luvit/luvit/issues/1019#issuecomment-3172841940

fixes #1019 