### PR TITLE
ci: update macos runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-13, ubuntu-latest]
+        os: [macos-15-intel, ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes the broken CI runs on MacOS due to deprecated macos-13 runners.