### PR TITLE
chore(ustring, querystring): version bump

### DIFF
--- a/deps/querystring.lua
+++ b/deps/querystring.lua
@@ -18,7 +18,7 @@ limitations under the License.
 
 --[[lit-meta
   name = "luvit/querystring"
-  version = "2.0.1"
+  version = "2.0.2"
   license = "Apache 2"
   homepage = "https://github.com/luvit/luvit/blob/master/deps/querystring.lua"
   description = "Node-style query-string codec for luvit"

--- a/deps/ustring.lua
+++ b/deps/ustring.lua
@@ -17,7 +17,7 @@ limitations under the License.
 --]]
 --[[lit-meta
   name = "luvit/ustring"
-  version = "2.0.2"
+  version = "2.0.3"
   homepage = "https://github.com/luvit/luvit/blob/master/deps/ustring.lua"
   description = "A light-weight UTF-8 module in pure lua(jit)."
   tags = {"ustring", "utf8", "utf-8", "unicode"}


### PR DESCRIPTION
Both packages have fixes merged, but not updated on lit.
Preferably, only merge this when you are ready to run `lit publish`, so we don't forget about them.