### PR TITLE
ci: make coveralls optional

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -5,6 +5,7 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   luacov:
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - name: Setup Luvit


### PR DESCRIPTION
Do not show a cross mark on commits that do not add new tests.

This stops the coveralls action from blocking the merge of such PRs. 